### PR TITLE
feat($browser): 图片增加跨域支持

### DIFF
--- a/src/canvas/shape/image.js
+++ b/src/canvas/shape/image.js
@@ -82,6 +82,7 @@ Util.augment(CImage, {
         self.set('loading', false);
       };
       image.src = img;
+      image.crossOrigin = 'Anonymous';
       self.set('loading', true);
     } else if (img instanceof Image) {
       if (!attrs.width) {


### PR DESCRIPTION
对于导出的 canvas，若包含跨域图片，则会造成 canvas 污染；增加跨域支持后可以解决这个问题

#40