### PR TITLE
fix(group): check destroyed before clear

### DIFF
--- a/src/core/group.js
+++ b/src/core/group.js
@@ -428,6 +428,9 @@ Util.augment(Group, {
     }
   },
   clear(delayRemove) {
+    if (this.get('destroyed')) {
+      return;
+    }
     const children = this._cfg.children;
     for (let i = children.length - 1; i >= 0; i--) {
       children[i].remove(true, delayRemove);


### PR DESCRIPTION
We should check destroyed before actually run clear. Otherwise the `_cfg,children` will be `undefined` and 
cause `children.length` throw an error.

The PR is intent to fix a downstream [issue](https://github.com/antvis/g2/issues/1097).