### PR TITLE
fix(marker): compatible with scenes where symbol does not exist

### DIFF
--- a/src/shapes/marker.js
+++ b/src/shapes/marker.js
@@ -103,6 +103,12 @@ Util.augment(Marker, {
     } else {
       method = Marker.Symbols[symbol];
     }
+
+    if (!method) {
+      console.warn(`${symbol} marker is not supported.`);
+      return null;
+    }
+
     return method(x, y, r);
   },
   createPath(context) {


### PR DESCRIPTION
关联 issue https://github.com/antvis/g2/issues/1158

![image](https://user-images.githubusercontent.com/6628666/54414553-806cdb80-4734-11e9-8079-cbdd44893f11.png)


