### PR TITLE
当文本从多行更新为单行时，bbox 的高度计算不正确（没有更新属性lineCount）

### DIFF
--- a/src/shapes/text.js
+++ b/src/shapes/text.js
@@ -64,10 +64,14 @@ Util.augment(CText, {
     const attrs = this._attrs;
     const text = attrs.text;
     let textArr = null;
-    if (Util.isString(text) && (text.indexOf('\n') !== -1)) {
-      textArr = text.split('\n');
-      const lineCount = textArr.length;
-      attrs.lineCount = lineCount;
+    if (Util.isString(text)) {
+      if (text.indexOf('\n') !== -1) {
+        textArr = text.split('\n');
+        const lineCount = textArr.length;
+        attrs.lineCount = lineCount;
+      } else {
+        attrs.lineCount = 1;
+      }
     }
     attrs.textArr = textArr;
   },

--- a/test/bugs/text-height-update-spec.js
+++ b/test/bugs/text-height-update-spec.js
@@ -1,0 +1,39 @@
+const expect = require('chai').expect;
+const G = require('../../src/index');
+const Canvas = G.Canvas;
+
+const div = document.createElement('div');
+div.id = 'text-height';
+document.body.appendChild(div);
+
+describe('#text height update', () => {
+  const canvas = new Canvas({
+    containerId: div.id,
+    renderer: 'canvas',
+    width: 500,
+    height: 500,
+    pixelRatio: 1
+  });
+
+  it('change mutil-line text to single line text', function() {
+    const lineWidth = 1;
+    const text = new G.Text({
+      attrs: {
+        x: 50,
+        y: 50,
+        lineHeight: 14,
+        fontSize: 14,
+        lineWidth,
+        text: '你好啊\n你好啊\n你好啊'
+      }
+    });
+    canvas.add(text);
+    canvas.draw();
+    const mulBox = text.getBBox();
+    text.attr('text', '你好啊');
+    const singleBox = text.getBBox();
+    expect(mulBox.width).to.equal(singleBox.width);
+    expect((mulBox.height - lineWidth) / 3).to.equal(singleBox.height - lineWidth);
+  });
+});
+


### PR DESCRIPTION
当文本从多行文本更新为单行文本是，文本的 bbox 高度计算不正确，根本原因是由于没有更新 lineCount属性，bug 重现代码如下：

```
  const canvas = new G.Canvas({
    containerId: 'canvas-dom',
    width: 200,
    height: 200,
    pixelRatio: 2,
    renderer: 'svg'
  });
  const lineWidth = 1;
  const text = new G.Text({
    attrs: {
      x: 50,
      y: 50,
      text: '你好啊\n你好啊\n你好啊',
      lineHeight: 14,
      fontSize: 14,
      lineWidth,
    }
  });
  // console.log((text.getBBox().height - lineWidth)/3);
  console.log(text.getBBox().height);
  text.attr({text: '你好啊'});
  console.log(text.getBBox().height);

  // console.log(text.getBBox().height - lineWidth);
  canvas.add(text);
  canvas.draw();
```