### PR TITLE
fix: g6 issue#732

### DIFF
--- a/src/core/mixin/event.js
+++ b/src/core/mixin/event.js
@@ -137,6 +137,15 @@ module.exports = {
         mousedownOffset = { x: e.clientX, y: e.clientY };
       }
       if (type === 'mouseup' && e.button === LEFT_BTN_CODE) {
+        if (dragging) {
+          mousedownShape = shape;
+          dragging._cfg.capture = true;
+          this._emitEvent('dragend', e, point, dragging);
+          dragging = null;
+          this._emitEvent('drop', e, point, shape || this);
+        } else {
+          mousedownOffset = { x: e.clientX, y: e.clientY };
+        }
         const dx = mousedownOffset.x - e.clientX;
         const dy = mousedownOffset.y - e.clientY;
         const dist = dx * dx + dy * dy;
@@ -144,12 +153,6 @@ module.exports = {
           clearTimeout(dragTimer);
           dragTimer = null;
           this._emitEvent('click', e, point, mousedownShape || this);
-        }
-        if (dragging) {
-          dragging._cfg.capture = true;
-          this._emitEvent('dragend', e, point, dragging);
-          dragging = null;
-          this._emitEvent('drop', e, point, shape || this);
         }
         mousedownShape = null;
       }


### PR DESCRIPTION
解决shape上的点击事件不一定被捕获的问题。

参考[G6 issues: 732](https://github.com/antvis/g6/issues/732)