### PR TITLE
fix(ci): bbox should contains x and y attribute

### DIFF
--- a/packages/g-canvas/__tests__/unit/shape/image-spec.js
+++ b/packages/g-canvas/__tests__/unit/shape/image-spec.js
@@ -31,7 +31,7 @@ describe('image test', () => {
       expect(image.attr('width')).eqls(50);
       expect(image.attr('height')).eqls(50);
       done();
-    }, 100);
+    }, 1000);
   });
 
   it('draw image by src', () => {

--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -26,11 +26,17 @@ class ShapeBase extends AbstractShape {
     const { x, y, width, height } = el.getBBox();
     const lineWidth = this.getHitLineWidth();
     const halfWidth = lineWidth / 2;
+    const minX = x - halfWidth;
+    const minY = y - halfWidth;
+    const maxX = x + width + halfWidth;
+    const maxY = y + height + halfWidth;
     return {
-      minX: x - halfWidth,
-      minY: y - halfWidth,
-      maxX: x + width + halfWidth,
-      maxY: y + height + halfWidth,
+      x: minX,
+      y: minY,
+      minX,
+      minY,
+      maxX,
+      maxY,
       width: width + lineWidth,
       height: height + lineWidth,
     };


### PR DESCRIPTION
- Broken CI link: https://travis-ci.org/antvis/g/builds/578682304
![image](https://user-images.githubusercontent.com/14918822/64001341-27ee9680-cb3a-11e9-9800-fbba4744d239.png)
