### PR TITLE
fix(g-canvas): context scale should be effective

### DIFF
--- a/packages/g-canvas/__tests__/bugs/issue-187-spec.js
+++ b/packages/g-canvas/__tests__/bugs/issue-187-spec.js
@@ -1,0 +1,38 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { getColor } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#187', () => {
+  const canvas = new Canvas({
+    container: dom,
+    autoDraw: true,
+    width: 1000,
+    height: 1000,
+  });
+
+  const context = canvas.get('context');
+  const pixelRatio = canvas.getPixelRatio();
+
+  it('pixelRatio should be effective', (done) => {
+    const group = canvas.addGroup();
+    group.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 10,
+        fill: 'red',
+      },
+    });
+
+    setTimeout(() => {
+      // getColor 函数获取的是实际渲染的图形，内部没有处理缩放逻辑，因此需要外部传入缩放后的坐标值
+      expect(getColor(context, 100 * pixelRatio, 100 * pixelRatio)).eqls('#ff0000');
+      expect(getColor(context, 100 * pixelRatio, (100 + 9) * pixelRatio)).eqls('#ff0000');
+      done();
+    }, 25);
+  });
+});

--- a/packages/g-canvas/__tests__/mocha.opts
+++ b/packages/g-canvas/__tests__/mocha.opts
@@ -1,3 +1,4 @@
 --require source-map-support/register
 --recursive
 __tests__/unit
+__tests__/bugs

--- a/packages/g-canvas/src/canvas.ts
+++ b/packages/g-canvas/src/canvas.ts
@@ -94,13 +94,7 @@ class Canvas extends AbstractCanvas {
   // 复写基类的方法生成标签
   createDom(): HTMLElement {
     const element = document.createElement('canvas');
-    const pixelRatio = this.getPixelRatio();
     const context = element.getContext('2d');
-    element.width = pixelRatio * this.get('width');
-    element.height = pixelRatio * this.get('height');
-    if (pixelRatio > 1) {
-      context.scale(pixelRatio, pixelRatio);
-    }
     // 缓存 context 对象
     this.set('context', context);
     return element;
@@ -204,6 +198,12 @@ class Canvas extends AbstractCanvas {
     let drawFrame = this.get('drawFrame');
     if (!drawFrame) {
       drawFrame = requestAnimationFrame(() => {
+        const context = this.get('context');
+        context.save();
+        const pixelRatio = this.getPixelRatio();
+        if (pixelRatio > 1) {
+          context.scale(pixelRatio, pixelRatio);
+        }
         if (this.get('localRefresh')) {
           this._drawRegion();
         } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #187 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 修改 `canvas` 元素的宽、高属性，会使得 `context.scale()` 失效。因此根据 `pixelRatio` 去做缩放需要在渲染时进行，而不是画布初始化时去做。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 修复 g-canvas 根据 `pixelRatio` 进行缩放操作不生效的问题。#187 |
| 🇨🇳 Chinese | 🐞 Fix that `context.scale()` is not effective according to `pixelRatio` for g-canvas. #187 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
