### PR TITLE
fix(g-canvas): autoDraw should be true by default

### DIFF
--- a/packages/g-canvas/__tests__/unit/canvas-spec.js
+++ b/packages/g-canvas/__tests__/unit/canvas-spec.js
@@ -40,7 +40,7 @@ describe('canvas test', () => {
     expect(canvas.getChildren().length).eql(1);
   });
 
-  it('add shape', () => {
+  it('add shape', (done) => {
     const circle = canvas.addShape({
       type: 'circle',
       attrs: {
@@ -52,13 +52,6 @@ describe('canvas test', () => {
     });
     expect(circle.get('type')).eql('circle');
     expect(circle.attr('r')).eql(10);
-  });
-
-  it('draw', (done) => {
-    expect(getColor(canvas.get('context'), 10, 10)).eql('#000000');
-    // 默认的 draw 是延迟的所以要延迟测试
-    canvas.draw();
-    expect(getColor(canvas.get('context'), 10, 10)).eql('#000000');
     setTimeout(() => {
       expect(getColor(canvas.get('context'), 10, 10)).eql('#ff0000');
       done();
@@ -88,7 +81,6 @@ describe('canvas test', () => {
         fill: 'red',
       },
     });
-    canvas.draw();
     let called = false;
     let clickShape = null;
     canvas.on('click', (ev) => {

--- a/packages/g-canvas/src/canvas.ts
+++ b/packages/g-canvas/src/canvas.ts
@@ -38,7 +38,7 @@ class Canvas extends AbstractCanvas {
   getDefaultCfg() {
     const cfg = super.getDefaultCfg();
     // 是否自动绘制，不需要用户调用 draw 方法
-    cfg['autoDraw'] = false;
+    cfg['autoDraw'] = true;
     // 是否允许局部刷新图表
     cfg['localRefresh'] = true;
     cfg['refreshElements'] = [];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- None.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- For `g-canvas`, `autoDraw` should be true by default.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 修复 g-canvas 的自动绘制功能没有默认开启。           |
| 🇨🇳 Chinese |  🐞 Fix that `autoDraw` should be true by default for g-canvas.          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
