### PR TITLE
fix(g-svg): autoDraw should be true and immutable to avoid redundant rendering when animating

### DIFF
--- a/packages/g-svg/__tests__/bugs/issue-191-spec.js
+++ b/packages/g-svg/__tests__/bugs/issue-191-spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import getCanvas from '../get-canvas';
+
+describe('#191', () => {
+  let canvas;
+  let circle;
+
+  before(() => {
+    canvas = getCanvas('svg-circle');
+    circle = canvas.addShape('circle', {
+      attrs: {
+        x: 20,
+        y: 20,
+        r: 20,
+        fill: 'red',
+      },
+    });
+  });
+
+  it.only('autoDraw should be true and immutable', () => {
+    expect(canvas.get('autoDraw')).eqls(true);
+    canvas.set('autoDraw', false);
+    expect(canvas.get('autoDraw')).eqls(true);
+  });
+
+  it.only('avoid redundant rendering when animating and repeat is true', (done) => {
+    circle.animate(
+      {
+        r: 40,
+      },
+      {
+        duration: 200,
+        repeat: true,
+      }
+    );
+    setTimeout(() => {
+      const count = document.getElementsByTagName('circle').length;
+      expect(count).eqls(1);
+      done();
+    }, 1000);
+  });
+});

--- a/packages/g-svg/src/canvas.ts
+++ b/packages/g-svg/src/canvas.ts
@@ -10,7 +10,21 @@ import Defs from './defs';
 
 class Canvas extends AbstractCanvas {
   constructor(cfg) {
-    super(cfg);
+    super({
+      ...cfg,
+      autoDraw: true,
+    });
+  }
+
+  // 覆盖基类中的 set 方法
+  set(name, value) {
+    // autoDraw 不可修改，始终为 true
+    // TODO: 应该在控制台给出 Warning 提示，引导用户避免这种用法。需要在 @antv/util 中提供通用的 warning 方法，便于在其他 antv 项目中使用
+    if (name === 'autoDraw') {
+      this.cfg[name] = true;
+    } else {
+      super.set(name, value);
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #191.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 执行和停止动画时，渲染更新是根据 `autoDraw` 来决定是否自动调用 `canvas.draw()`:
```js
// timeline.ts
const autoDraw = this.canvas.get('autoDraw');
// 非自动更新模式下，需要手动更新
if (!autoDraw) {
  this.canvas.draw();
}
```
- `g-svg` 只支持自动渲染模式，但却没有设置 `autoDraw: true`，使得动画执行时会调用 `canavs.draw()`，导致生成多个 SVG 元素。因此需要设置 `autoDraw: true`，且外部不可修改，避免出现 #191 中的问题。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 Fix redundant rendering for g-svg when animating. #191          |
| 🇨🇳 Chinese | 🐞 修复 g-svg 执行动画时同一元素重复渲染的问题。#191 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
