### PR TITLE
fix(g-canvas): make non-array value compatible with lineDash

### DIFF
--- a/packages/g-canvas/__tests__/bugs/issue-206-spec.js
+++ b/packages/g-canvas/__tests__/bugs/issue-206-spec.js
@@ -1,0 +1,43 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { getColor } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#187', () => {
+  const canvas = new Canvas({
+    container: dom,
+    pixelRatio: 1,
+    width: 500,
+    height: 500,
+  });
+
+  const context = canvas.get('context');
+
+  it('non-array value should be compatible with lineDash', (done) => {
+    const circle = canvas.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 40,
+        lineWidth: 5,
+        fill: 'red',
+        stroke: 'blue',
+      },
+    });
+    circle.attr('lineDash', [40, 40]);
+    setTimeout(() => {
+      expect(getColor(context, 100, 100 + 41)).eqls('#000000');
+      expect(getColor(context, 100, 100 - 41)).eqls('#0000ff');
+      // null should be equivalent to empty array
+      circle.attr('lineDash', null);
+      setTimeout(() => {
+        expect(getColor(context, 100, 100 + 41)).eqls('#0000ff');
+        expect(getColor(context, 100, 100 - 41)).eqls('#0000ff');
+        done();
+      }, 25);
+    }, 25);
+  });
+});

--- a/packages/g-canvas/src/util/draw.ts
+++ b/packages/g-canvas/src/util/draw.ts
@@ -1,3 +1,4 @@
+import { isArray } from '@antv/util';
 import { IElement } from '../interfaces';
 import { Region } from '../types';
 import { parseStyle } from './parse';
@@ -20,8 +21,8 @@ export function applyAttrsToContext(context: CanvasRenderingContext2D, element: 
       // 设置矩阵
       context.transform(v[0], v[1], v[3], v[4], v[6], v[7]);
     } else if (name === 'lineDash' && context.setLineDash) {
-      // 不再考虑支持字符串的形式
-      context.setLineDash(v);
+      // 设置虚线，只支持数组形式，非数组形式不做任何操作
+      isArray(v) && context.setLineDash(v);
     } else {
       if (name === 'strokeStyle' || name === 'fillStyle') {
         // 如果存在渐变、pattern 这个开销有些大


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #206.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- Non-array value is equivalent to empty array for `lineDash` attribute.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix that non-array value is not compatible with lineDash. #206 |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复 `lineDash` 为非数组值时页面报错的问题。 #206 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
