### PR TITLE
docs: Upgrade theme config

### DIFF
--- a/docs/api/canvas.en.md
+++ b/docs/api/canvas.en.md
@@ -1,4 +1,6 @@
 ---
 title: Canvas
 order: 0
+redirect_from:
+  - /en/docs/api
 ---

--- a/docs/api/canvas.zh.md
+++ b/docs/api/canvas.zh.md
@@ -1,4 +1,6 @@
 ---
 title: 画布
 order: 0
+redirect_from:
+  - /zh/docs/api
 ---

--- a/docs/guide/getting-started.en.md
+++ b/docs/guide/getting-started.en.md
@@ -1,4 +1,6 @@
 ---
 title: Getting Started
 order: 1
+redirect_from:
+  - /en/docs/guide
 ---

--- a/docs/guide/getting-started.zh.md
+++ b/docs/guide/getting-started.zh.md
@@ -1,4 +1,6 @@
 ---
 title: 快速上手
 order: 1
+redirect_from:
+  - /zh/docs/guide
 ---

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,7 +20,6 @@ module.exports = {
           zh: '教程',
           en: 'Guide',
         },
-        redirect: 'getting-started',
       },
       {
         slug: 'docs/api',
@@ -28,7 +27,6 @@ module.exports = {
           zh: '接口',
           en: 'API',
         },
-        redirect: 'canvas',
       },
     ],
     docs: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,16 +13,25 @@ module.exports = {
     title: 'G',
     description: 'A powerful rendering engine for AntV providing canvas and svg draw',
     githubUrl: 'https://github.com/antvis/g',
-    docs: [
+    navs: [
       {
-        slug: 'guide',
+        slug: 'docs/guide',
         title: {
           zh: '教程',
           en: 'Guide',
         },
-        order: 0,
         redirect: 'getting-started',
       },
+      {
+        slug: 'docs/api',
+        title: {
+          zh: '接口',
+          en: 'API',
+        },
+        redirect: 'canvas',
+      },
+    ],
+    docs: [
       {
         slug: 'guide/render',
         title: {
@@ -54,15 +63,6 @@ module.exports = {
           en: 'Animation',
         },
         order: 5,
-      },
-      {
-        slug: 'api',
-        title: {
-          zh: '接口',
-          en: 'API',
-        },
-        order: 0,
-        redirect: 'canvas',
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish": "lerna publish",
     "publish-beta": "npm run pre-publish && lerna publish --dist-tag beta",
     "start": "npm run site:develop",
-    "site:develop": "gatsby develop --open",
+    "site:develop": "gatsby develop --open -H 0.0.0.0",
     "site:build": "npm run site:clean && gatsby build --prefix-paths",
     "site:clean": "gatsby clean",
     "site:deploy": "npm run site:build && gh-pages -d public"
@@ -46,7 +46,7 @@
     }
   },
   "dependencies": {
-    "@antv/gatsby-theme-antv": "^0.9.2",
+    "@antv/gatsby-theme-antv": "^0.9.3",
     "@antv/istanbul": "0.0.0",
     "@antv/torch": "^1.0.0",
     "gatsby": "^2.15.34",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "dependencies": {
-    "@antv/gatsby-theme-antv": "^0.9.3",
+    "@antv/gatsby-theme-antv": "^0.9.4",
     "@antv/istanbul": "0.0.0",
     "@antv/torch": "^1.0.0",
     "gatsby": "^2.15.34",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "dependencies": {
-    "@antv/gatsby-theme-antv": "^0.7.4",
+    "@antv/gatsby-theme-antv": "^0.9.2",
     "@antv/istanbul": "0.0.0",
     "@antv/torch": "^1.0.0",
     "gatsby": "^2.15.34",


### PR DESCRIPTION
- https://github.com/antvis/g2plot/pull/174
- https://github.com/antvis/g/pull/251

重新定义了一下 gatsby-config.js 的配置，有一些不兼容。

- [x] 新增了 `navs` 用于定义顶部菜单。
- [x] `examples` 里的 `slug` 统一移除掉 `examples` 前缀。
- [x] `docs` 里的一级目录移到 `navs` 上。
- [x] 干掉 `redirect`，在 md 里直接定义 `redirect_from`。