### PR TITLE
fix: text.measureText() returns wrong height in multiple lines of text

### DIFF
--- a/src/shapes/text.js
+++ b/src/shapes/text.js
@@ -226,8 +226,8 @@ Util.augment(CText, {
 
     if (Util.isNil(text)) return undefined;
     const context = document.createElement('canvas').getContext('2d');
-    context.save();
     context.font = font;
+    context.save();
     if (textArr) {
       Util.each(textArr, subText => {
         measureWidth = context.measureText(subText).width;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

#253 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

原代码中在`context.save()`之后设置`context.font`，导致遇到多行文本时，每次`context.restore()`之后从第二行开始计算的宽度是不对的(因为`font`不一致)。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 Fixed text.measureText() returns wrong height in multiple lines of text        |
| 🇨🇳 Chinese |  🐞 修复`text`在计算多行文本高度时，高度不正确的问题  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
