### PR TITLE
fix(g-canvas): bbox calculation for path is incorrect when angle is 0 and π

### DIFF
--- a/packages/g-canvas/src/util/path.ts
+++ b/packages/g-canvas/src/util/path.ts
@@ -167,6 +167,9 @@ function getExtraFromSegmentWithAngle(segment, lineWidth) {
   const angleCurrent = Math.acos(
     (currentAndPre + currentAndNext - preAndNext) / (2 * Math.sqrt(currentAndPre) * Math.sqrt(currentAndNext))
   );
+  if (Math.sin(angleCurrent) === 0) {
+    return 0;
+  }
   // 这里不考虑在水平和垂直方向的投影，直接使用最大差值
   // 由于上层统一加减了二分之一线宽，这里需要进行弥补
   return lineWidth * (1 / Math.sin(angleCurrent / 2)) + lineWidth / 2 || 0;

--- a/packages/g-canvas/tests/bugs/issue-254-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-254-spec.js
@@ -1,0 +1,30 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#254', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+  });
+
+  it('bbox calculation for path should consider angle of 0 and PI', () => {
+    const shape = canvas.addShape({
+      type: 'path',
+      attrs: {
+        path: [['M', 300, 500], ['L', 300, 375], ['L', 300, 500], ['Z']],
+        lineWidth: 5,
+        stroke: 'red',
+      },
+    });
+    const bbox = shape.getBBox();
+    expect(bbox.minX).eqls(297.5);
+    expect(bbox.minY).eqls(372.5);
+    expect(bbox.maxX).eqls(302.5);
+    expect(bbox.maxY).eqls(502.5);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #254.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix that bbox calculation for path is incorrect when angle is 0 and π. #254.          |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复当 `path` 的夹角为 0 和 π 时，包围盒计算错误的问题。#254.          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
