### PR TITLE
fix(g-canvas): stroke attr should be working for Text

### DIFF
--- a/packages/g-canvas/src/shape/text.ts
+++ b/packages/g-canvas/src/shape/text.ts
@@ -210,7 +210,11 @@ class Text extends ShapeBase {
       this._drawTextArr(context, textArr, isFill);
     } else {
       const text = attrs.text;
-      context.fillText(text, x, y);
+      if (isFill) {
+        context.fillText(text, x, y);
+      } else {
+        context.strokeText(text, x, y);
+      }
     }
   }
 

--- a/packages/g-canvas/tests/bugs/issue-266-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-266-spec.js
@@ -1,0 +1,35 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { getTextColorCount } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#266', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+    pixelRatio: 1,
+  });
+
+  const context = canvas.get('context');
+
+  it('stroke attr should be working for Text', (done) => {
+    canvas.addShape('text', {
+      attrs: {
+        x: 100,
+        y: 100,
+        text: 'This is text',
+        fontSize: 60,
+        stroke: 'red',
+        textBaseline: 'top',
+      },
+    });
+    setTimeout(() => {
+      expect(getTextColorCount(context, 110, 110, 50, '#ff0000') > 0).eqls(true);
+      done();
+    }, 25);
+  });
+});

--- a/packages/g-canvas/tests/get-color.ts
+++ b/packages/g-canvas/tests/get-color.ts
@@ -22,3 +22,14 @@ export function colorToValue(color) {
   const str = color.substr(1);
   return parseInt(str, 16);
 }
+
+// 验证文字是否绘制出来，扫描一条线，看看是否有对应的颜色
+export function getTextColorCount(ctx, x, y, length, color) {
+  let count = 0;
+  for (let i = x; i < x + length; i++) {
+    if (getColor(ctx, i, y) === color) {
+      count++;
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #266.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix that `stroke` attr is not working for Text. #266         |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复 Text 的 `stroke` 属性不生效的问题。#266          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
