### PR TITLE
feat: 通过属性配置Text shape绘制的max width

### DIFF
--- a/__tests__/unit/canvas/shape/text-spec.js
+++ b/__tests__/unit/canvas/shape/text-spec.js
@@ -440,6 +440,49 @@ describe('Text \n', function() {
     expect(text.attr('textBaseline')).to.equal('top');
     expect(text.attr('lineWidth')).to.equal(1);
   });
+  it('text max-width', () => {
+    const text = new G.Text({
+      attrs: {
+        x: 0,
+        y: 20,
+        text: '无最长宽度90限制的文本',
+        fill: 'black',
+        fontSize: 14,
+        stroke: 'red',
+      },
+    });
+    const textLimit = new G.Text({
+      attrs: {
+        x: 0,
+        y: 50,
+        text: '有最长宽度90限制的文本',
+        fill: 'black',
+        fontSize: 14,
+        maxWidth: 90,
+        stroke: 'red',
+        lineWidth: 2
+      },
+    });
+    const textZeroWidth = new G.Text({
+      attrs: {
+        x: 0,
+        y: 50,
+        text: '有最长宽度0限制的文本',
+        fill: 'black',
+        fontSize: 14,
+        maxWidth: 0,
+        stroke: 'red',
+      },
+    });
+    canvas.add(text);
+    canvas.add(textLimit);
+    canvas.add(textZeroWidth);
+    expect(text.getBBox().width).not.to.equal(90);
+    expect(textLimit.attr('maxWidth')).to.equal(90);
+    expect(textLimit.getBBox().width).to.equal(90 + textLimit.attr('lineWidth'));
+    expect(textZeroWidth.getBBox().width).to.equal(0);
+    canvas.draw();
+  });
 });
 
 describe('Text 不存在', function() {

--- a/src/shapes/text.ts
+++ b/src/shapes/text.ts
@@ -161,6 +161,7 @@ class CText extends Shape {
     const textArr = attrs.textArr;
     const x = attrs.x;
     const y = attrs.y;
+    const maxWidth = attrs.maxWidth;
 
     context.beginPath();
     if (self.hasStroke()) {
@@ -171,7 +172,7 @@ class CText extends Shape {
       if (textArr) {
         self._drawTextArr(context, false);
       } else {
-        context.strokeText(text, x, y);
+        context.strokeText(text, x, y, maxWidth);
       }
       context.globalAlpha = 1;
     }
@@ -183,7 +184,7 @@ class CText extends Shape {
       if (textArr) {
         self._drawTextArr(context, true);
       } else {
-        context.fillText(text, x, y);
+        context.fillText(text, x, y, maxWidth);
       }
     }
     cfg.hasUpdate = false;
@@ -196,6 +197,7 @@ class CText extends Shape {
     const spaceingY = this._getSpaceingY();
     const x = this.attrs.x;
     const y = this.attrs.y;
+    const maxWidth = this.attrs.maxWidth;
     const box = this.getBBox();
     const height = box.maxY - box.minY;
     let subY;
@@ -205,9 +207,9 @@ class CText extends Shape {
       if (textBaseline === 'middle') subY += height - fontSize - (height - fontSize) / 2;
       if (textBaseline === 'top') subY += height - fontSize;
       if (fill) {
-        context.fillText(subText, x, subY);
+        context.fillText(subText, x, subY, maxWidth);
       } else {
-        context.strokeText(subText, x, subY);
+        context.strokeText(subText, x, subY, maxWidth);
       }
     });
   }
@@ -236,6 +238,9 @@ class CText extends Shape {
     } else {
       width = context.measureText(text).width;
       context.restore();
+    }
+    if (attrs.maxWidth !== undefined) {
+      width = Math.min(attrs.maxWidth, width);
     }
     return width;
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [x] New feature
- [x] add test-cases

通过外部设置 text shape的`maxWidth`属性，设置text绘制的max-width，从而允许绘制更多文字
效果如下：
![image](https://user-images.githubusercontent.com/15646325/69510918-985e5580-0f79-11ea-96f2-b8382431d04b.png)
设置maxWidth后，字体缩小
![image](https://user-images.githubusercontent.com/15646325/69510946-a44a1780-0f79-11ea-904e-28f0c3cec17b.png)
