### PR TITLE
fix(g-svg): group.addShape should work when group dom is not created

### DIFF
--- a/packages/g-svg/src/canvas.ts
+++ b/packages/g-svg/src/canvas.ts
@@ -1,8 +1,9 @@
 import { AbstractCanvas } from '@antv/g-base';
 import { ChangeType } from '@antv/g-base/lib/types';
 import { IElement } from './interfaces';
-import { applyClipChildren, drawPathChildren, refreshElement } from './util/draw';
-import { setClip } from './util/svg';
+import { applyClipChildren, drawPathChildren } from './util/draw';
+import { setTransform, setClip } from './util/svg';
+import { sortDom } from './util/dom';
 import EventController from '@antv/g-base/lib/event/event-contoller';
 import * as Shape from './shape';
 import Group from './group';
@@ -32,7 +33,28 @@ class Canvas extends AbstractCanvas {
    * @param {ChangeType} changeType 改变的类型
    */
   onCanvasChange(changeType: ChangeType) {
-    refreshElement(this, changeType);
+    const context = this.get('context');
+    const el = this.get('el');
+    if (changeType === 'sort') {
+      const children = this.get('children');
+      if (children && children.length) {
+        sortDom(this, (a: IElement, b: IElement) => {
+          return children.indexOf(a) - children.indexOf(b) ? 1 : 0;
+        });
+      }
+    } else if (changeType === 'clear') {
+      // el is null for canvas
+      if (el) {
+        el.innerHTML = '';
+      }
+    } else if (changeType === 'matrix') {
+      setTransform(this);
+    } else if (changeType === 'clip') {
+      this.applyClip(context);
+    } else if (changeType === 'changeSize') {
+      el.setAttribute('width', `${this.get('width')}`);
+      el.setAttribute('height', `${this.get('height')}`);
+    }
   }
 
   getShapeBase() {

--- a/packages/g-svg/src/group.ts
+++ b/packages/g-svg/src/group.ts
@@ -34,9 +34,13 @@ class Group extends AbstractGroup {
 
   // 覆盖基类的 afterAttrsChange 方法
   afterAttrsChange(targetAttrs) {
-    const context = this.get('context');
     super.afterAttrsChange(targetAttrs);
-    this.createPath(context, targetAttrs);
+    const canvas = this.get('canvas');
+    // 只有挂载到画布下，才对元素进行实际渲染
+    if (canvas) {
+      const context = canvas.get('context');
+      this.updatePath(context, targetAttrs);
+    }
   }
 
   /**
@@ -59,7 +63,7 @@ class Group extends AbstractGroup {
     const children = this.getChildren() as IElement[];
     setClip(this, context);
     this.createDom();
-    this.createPath(context);
+    this.updatePath(context);
     if (children.length) {
       drawChildren(context, children);
     }
@@ -76,13 +80,13 @@ class Group extends AbstractGroup {
   drawPath(context: Defs) {
     const children = this.getChildren() as IElement[];
     this.createDom();
-    this.createPath(context);
+    this.updatePath(context);
     if (children.length) {
       drawPathChildren(context, children);
     }
   }
 
-  createPath(context: Defs, targetAttrs?) {
+  updatePath(context: Defs, targetAttrs?) {
     const attrs = this.attr();
     const el = this.get('el');
     each(targetAttrs || attrs, (value, attr) => {

--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -26,8 +26,11 @@ class ShapeBase extends AbstractShape implements IShape {
   afterAttrsChange(targetAttrs: ShapeAttrs) {
     super.afterAttrsChange(targetAttrs);
     const canvas = this.get('canvas');
-    const context = canvas.get('context');
-    this.updatePath(context, targetAttrs);
+    // 只有挂载到画布下，才对元素进行实际渲染
+    if (canvas) {
+      const context = canvas.get('context');
+      this.updatePath(context, targetAttrs);
+    }
   }
 
   /**

--- a/packages/g-svg/src/util/dom.ts
+++ b/packages/g-svg/src/util/dom.ts
@@ -1,5 +1,5 @@
 import { toArray } from '@antv/util';
-import { IShape, IElement } from '../interfaces';
+import { IShape, IGroup, IElement } from '../interfaces';
 import { SHAPE_TO_TAGS } from '../constant';
 
 /**
@@ -21,11 +21,14 @@ export function createDom(shape: IShape) {
   shape.set('attrs', {});
   if (parent) {
     let parentNode = parent.get('el');
-    while (!parentNode) {
-      const newParent = parent.getParent();
-      parentNode = newParent && newParent.get('el');
+    if (parentNode) {
+      parentNode.appendChild(element);
+    } else {
+      // parentNode maybe null for group
+      parentNode = (parent as IGroup).createDom();
+      parent.set('el', parentNode);
+      parentNode.appendChild(element);
     }
-    parentNode.appendChild(element);
   }
   return element;
 }

--- a/packages/g-svg/src/util/draw.ts
+++ b/packages/g-svg/src/util/draw.ts
@@ -25,51 +25,49 @@ export function drawPathChildren(context: Defs, children: IElement[]) {
 }
 
 /**
- * 更新元素，包括 canvas、group 和 shape
- * @param {IElement} element    SVG 元素
+ * 更新元素，包括 group 和 shape
+ * @param {IElement} element       SVG 元素
  * @param {ChangeType} changeType  更新类型
  */
 export function refreshElement(element: IElement, changeType: ChangeType) {
-  // element maybe canvas
-  const canvas = element.get('canvas') || element;
-  // should get context from canvas
-  const context = canvas.get('context');
-  const parent = element.getParent();
-  const parentChildren = parent ? parent.getChildren() : [canvas];
-  const el = element.get('el');
-  if (changeType === 'remove') {
-    if (el && el.parentNode) {
-      el.parentNode.removeChild(el);
+  // 对于还没有挂载到画布下的元素，canvas 可能为空
+  const canvas = element.get('canvas');
+  // 只有挂载到画布下，才对元素进行实际渲染
+  if (canvas) {
+    const context = canvas && canvas.get('context');
+    const parent = element.getParent();
+    const parentChildren = parent ? parent.getChildren() : [canvas];
+    const el = element.get('el');
+    if (changeType === 'remove') {
+      if (el && el.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+    } else if (changeType === 'show') {
+      el.setAttribute('visibility', 'visible');
+    } else if (changeType === 'hide') {
+      el.setAttribute('visibility', 'hidden');
+    } else if (changeType === 'zIndex') {
+      moveTo(el, parentChildren.indexOf(element));
+    } else if (changeType === 'sort') {
+      const children = element.get('children');
+      if (children && children.length) {
+        sortDom(element, (a: IElement, b: IElement) => {
+          return children.indexOf(a) - children.indexOf(b) ? 1 : 0;
+        });
+      }
+    } else if (changeType === 'clear') {
+      // el is null for group
+      if (el) {
+        el.innerHTML = '';
+      }
+    } else if (changeType === 'matrix') {
+      setTransform(element);
+    } else if (changeType === 'clip') {
+      element.applyClip(context);
+    } else if (changeType === 'attr') {
+      // 已在 afterAttrsChange 进行了处理，此处 do nothing
+    } else if (changeType === 'add') {
+      element.drawPath(context);
     }
-  } else if (changeType === 'show') {
-    el.setAttribute('visibility', 'visible');
-  } else if (changeType === 'hide') {
-    el.setAttribute('visibility', 'hidden');
-  } else if (changeType === 'zIndex') {
-    moveTo(el, parentChildren.indexOf(element));
-  } else if (changeType === 'sort') {
-    const children = element.get('children');
-    if (children && children.length) {
-      sortDom(element, (a: IElement, b: IElement) => {
-        return children.indexOf(a) - children.indexOf(b) ? 1 : 0;
-      });
-    }
-  } else if (changeType === 'clear') {
-    // el is null for group
-    if (el) {
-      el.innerHTML = '';
-    }
-  } else if (changeType === 'matrix') {
-    setTransform(element);
-  } else if (changeType === 'clip') {
-    element.applyClip(context);
-  } else if (changeType === 'changeSize') {
-    const canvasEl = canvas.get('el');
-    canvasEl.setAttribute('width', `${canvas.get('width')}`);
-    canvasEl.setAttribute('height', `${canvas.get('height')}`);
-  } else if (changeType === 'attr') {
-    // 已在 afterAttrsChange 进行了处理，此处 do nothing
-  } else if (changeType === 'add') {
-    element.drawPath(context);
   }
 }

--- a/packages/g-svg/tests/bugs/issue-276-spec.js
+++ b/packages/g-svg/tests/bugs/issue-276-spec.js
@@ -1,0 +1,36 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import Group from '../../src/group';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#276', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+  });
+
+  it('should work correctly when group and shape are not mounted under canvas', () => {
+    const group = new Group({});
+    const shape = group.addShape('marker', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 30,
+        fill: 'red',
+        symbol: 'circle',
+      },
+    });
+    expect(shape.attr('fill')).eqls('red');
+    expect(shape.get('el')).eqls(undefined);
+    expect(canvas.getChildren().length).eqls(0);
+    shape.attr('fill', 'blue');
+    canvas.add(group);
+    expect(shape.get('el')).not.eqls(undefined);
+    expect(shape.attr('fill')).eqls('blue');
+    expect(canvas.getChildren().length).eqls(1);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #276 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- Just create dom when `parentNode` is null.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix that group.addShape should work when group dom is not created. #276      |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复当图形分组没有对应的 `el` 元素时，调用 addShape 方法导致死循环的问题。#276          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
