### PR TITLE
fix(g-base): animation should work when interpolate for null matrix

### DIFF
--- a/packages/g-base/src/animate/timeline.ts
+++ b/packages/g-base/src/animate/timeline.ts
@@ -7,6 +7,8 @@ import { isColorProp, isGradientColor } from '../util/color';
 import { ICanvas, IElement } from '../interfaces';
 import { Animation } from '../types';
 
+const IDENTITY_MATRIX = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
 /**
  * 使用 ratio 进行插值计算来更新属性
  * @param {IElement}  shape    元素
@@ -57,7 +59,11 @@ function _update(shape: IElement, animation: Animation, ratio: number) {
           cProps[k].push(cPathPoint);
         }
       } else if (k === 'matrix') {
-        const matrixFn = interpolateArray(fromAttrs[k], toAttrs[k]);
+        /* 
+         对矩阵进行插值时，需要保证矩阵不为空，为空则使用单位矩阵
+         TODO: 二维和三维场景下单位矩阵不同，之后 WebGL 版需要做进一步处理
+         */
+        const matrixFn = interpolateArray(fromAttrs[k] || IDENTITY_MATRIX, toAttrs[k] || IDENTITY_MATRIX);
         const currentMatrix = matrixFn(ratio);
         shape.setMatrix(currentMatrix);
       } else if (isColorProp(k) && isGradientColor(toAttrs[k])) {

--- a/packages/g-canvas/tests/bugs/issue-273-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-273-spec.js
@@ -1,0 +1,39 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#273', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+  });
+
+  it('animation should work when interpolate for null matrix', (done) => {
+    const circle = canvas.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 100,
+        fill: 'fill',
+        matrix: [1, 0, 0, 0, 1, 0, 20, 20, 1],
+      },
+    });
+    circle.animate(
+      {
+        matrix: null,
+      },
+      {
+        duration: 100,
+      }
+    );
+    setTimeout(() => {
+      // 动画运行过程中，矩阵插值结果不为空数组
+      expect(circle.getMatrix()).not.eqls([]);
+      done();
+    }, 50);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #273.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- Use identity matrix for interpolate when matrix is null.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix that animation does not work when interpolate for null matrix. #273      |
| 🇨🇳 Chinese | 🐞 [g-base] 修复当对值为空的矩阵进行插值时，动画不生效的问题。#273          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
