### PR TITLE
fix(g-svg): el maybe undefined when calculate bbox

### DIFF
--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -43,22 +43,35 @@ class ShapeBase extends AbstractShape implements IShape {
 
   calculateBBox(): BBox {
     const el = this.get('el');
-    const { x, y, width, height } = el.getBBox();
-    const lineWidth = this.getHitLineWidth();
-    const halfWidth = lineWidth / 2;
-    const minX = x - halfWidth;
-    const minY = y - halfWidth;
-    const maxX = x + width + halfWidth;
-    const maxY = y + height + halfWidth;
+    // 包围盒计算依赖于绘制，如果还没有生成对应的 Dom 元素，则包围盒的长宽均为 0
+    if (el) {
+      const { x, y, width, height } = el.getBBox();
+      const lineWidth = this.getHitLineWidth();
+      const halfWidth = lineWidth / 2;
+      const minX = x - halfWidth;
+      const minY = y - halfWidth;
+      const maxX = x + width + halfWidth;
+      const maxY = y + height + halfWidth;
+      return {
+        x: minX,
+        y: minY,
+        minX,
+        minY,
+        maxX,
+        maxY,
+        width: width + lineWidth,
+        height: height + lineWidth,
+      };
+    }
     return {
-      x: minX,
-      y: minY,
-      minX,
-      minY,
-      maxX,
-      maxY,
-      width: width + lineWidth,
-      height: height + lineWidth,
+      x: 0,
+      y: 0,
+      minX: 0,
+      minY: 0,
+      maxX: 0,
+      maxY: 0,
+      width: 0,
+      height: 0,
     };
   }
 

--- a/packages/g-svg/tests/bugs/issue-276-spec.js
+++ b/packages/g-svg/tests/bugs/issue-276-spec.js
@@ -15,20 +15,31 @@ describe('#276', () => {
 
   it('should work correctly when group and shape are not mounted under canvas', () => {
     const group = new Group({});
-    const shape = group.addShape('marker', {
+    const shape = group.addShape('circle', {
       attrs: {
         x: 100,
         y: 100,
-        r: 30,
+        r: 50,
         fill: 'red',
-        symbol: 'circle',
       },
     });
+    // before mounted under canvas
     expect(shape.attr('fill')).eqls('red');
     expect(shape.get('el')).eqls(undefined);
+    let bbox = shape.getBBox();
+    expect(bbox.minX).eqls(0);
+    expect(bbox.minY).eqls(0);
+    expect(bbox.maxX).eqls(0);
+    expect(bbox.maxY).eqls(0);
     expect(canvas.getChildren().length).eqls(0);
-    shape.attr('fill', 'blue');
+    // after mounted under canvas
     canvas.add(group);
+    shape.attr('fill', 'blue');
+    bbox = shape.getBBox();
+    expect(bbox.minX).eqls(50);
+    expect(bbox.minY).eqls(50);
+    expect(bbox.maxX).eqls(150);
+    expect(bbox.maxY).eqls(150);
     expect(shape.get('el')).not.eqls(undefined);
     expect(shape.attr('fill')).eqls('blue');
     expect(canvas.getChildren().length).eqls(1);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix that el maybe undefined when calculate bbox for shape.           |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复计算图形的包围盒时，`el` 为空导致页面报错的问题。          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
