### PR TITLE
fix(g-canvas): should render correctly when start point and end point are same for arc

### DIFF
--- a/packages/g-canvas/src/util/arc-params.ts
+++ b/packages/g-canvas/src/util/arc-params.ts
@@ -1,13 +1,14 @@
-import { mod, toRadian} from './util';
+import { mod, toRadian, isSamePoint } from './util';
 
 // 向量长度
 function vMag(v) {
   return Math.sqrt(v[0] * v[0] + v[1] * v[1]);
 }
 
-// u.v/|u||v|
+// u.v/|u||v|，计算夹角的余弦值
 function vRatio(u, v) {
-  return (u[0] * v[0] + u[1] * v[1]) / (vMag(u) * vMag(v));
+  // 当存在一个向量的长度为 0 时，夹角也为 0，即夹角的余弦值为 1
+  return vMag(u) * vMag(v) ? (u[0] * v[0] + u[1] * v[1]) / (vMag(u) * vMag(v)) : 1;
 }
 
 // 向量角度
@@ -22,20 +23,23 @@ export default function getArcParams(startPoint, params) {
   const xRotation = mod(toRadian(params[3]), Math.PI * 2);
   const arcFlag = params[4];
   const sweepFlag = params[5];
+  // 弧形起点坐标
   const x1 = startPoint[0];
   const y1 = startPoint[1];
+  // 弧形终点坐标
   const x2 = params[6];
   const y2 = params[7];
-  const xp = Math.cos(xRotation) * (x1 - x2) / 2.0 + Math.sin(xRotation) * (y1 - y2) / 2.0;
-  const yp = -1 * Math.sin(xRotation) * (x1 - x2) / 2.0 + Math.cos(xRotation) * (y1 - y2) / 2.0;
+  const xp = (Math.cos(xRotation) * (x1 - x2)) / 2.0 + (Math.sin(xRotation) * (y1 - y2)) / 2.0;
+  const yp = (-1 * Math.sin(xRotation) * (x1 - x2)) / 2.0 + (Math.cos(xRotation) * (y1 - y2)) / 2.0;
   const lambda = (xp * xp) / (rx * rx) + (yp * yp) / (ry * ry);
 
   if (lambda > 1) {
     rx *= Math.sqrt(lambda);
     ry *= Math.sqrt(lambda);
   }
-  const diff = (rx * rx) * (yp * yp) + (ry * ry) * (xp * xp);
-  let f = Math.sqrt((((rx * rx) * (ry * ry)) - diff) / diff);
+  const diff = rx * rx * (yp * yp) + ry * ry * (xp * xp);
+
+  let f = diff ? Math.sqrt((rx * rx * (ry * ry) - diff) / diff) : 1;
 
   if (arcFlag === sweepFlag) {
     f *= -1;
@@ -44,15 +48,22 @@ export default function getArcParams(startPoint, params) {
     f = 0;
   }
 
-  const cxp = f * rx * yp / ry;
-  const cyp = f * -ry * xp / rx;
+  // 旋转前的起点坐标
+  const cxp = (f * rx * yp) / ry;
+  const cyp = (f * -ry * xp) / rx;
 
+  // 椭圆圆心坐标
   const cx = (x1 + x2) / 2.0 + Math.cos(xRotation) * cxp - Math.sin(xRotation) * cyp;
   const cy = (y1 + y2) / 2.0 + Math.sin(xRotation) * cxp + Math.cos(xRotation) * cyp;
 
-  const theta = vAngle([ 1, 0 ], [ (xp - cxp) / rx, (yp - cyp) / ry ]);
-  const u = [ (xp - cxp) / rx, (yp - cyp) / ry ];
-  const v = [ (-1 * xp - cxp) / rx, (-1 * yp - cyp) / ry ];
+  // 起始点的单位向量
+  const u = [(xp - cxp) / rx, (yp - cyp) / ry];
+  // 终止点的单位向量
+  const v = [(-1 * xp - cxp) / rx, (-1 * yp - cyp) / ry];
+  // 计算起始点和圆心的连线，与 x 轴正方向的夹角
+  const theta = vAngle([1, 0], u);
+
+  // 计算圆弧起始点和终止点与椭圆圆心连线的夹角
   let dTheta = vAngle(u, v);
 
   if (vRatio(u, v) <= -1) {
@@ -70,8 +81,9 @@ export default function getArcParams(startPoint, params) {
   return {
     cx,
     cy,
-    rx,
-    ry,
+    // 弧形的起点和终点相同时，长轴和短轴的长度按 0 处理
+    rx: isSamePoint(startPoint, [x2, y2]) ? 0 : rx,
+    ry: isSamePoint(startPoint, [x2, y2]) ? 0 : ry,
     startAngle: theta,
     endAngle: theta + dTheta,
     xRotation,

--- a/packages/g-canvas/src/util/path.ts
+++ b/packages/g-canvas/src/util/path.ts
@@ -6,7 +6,7 @@ import getArcParams from './arc-params';
 import QuadUtil from '@antv/g-math/lib/quadratic';
 import CubicUtil from '@antv/g-math/lib/cubic';
 import EllipseArcUtil from '@antv/g-math/lib/arc';
-import { inBox } from './util';
+import { inBox, isSamePoint } from './util';
 import inLine from './in-stroke/line';
 import inArc from './in-stroke/arc';
 
@@ -170,11 +170,6 @@ function getPathBox(segments, lineWidth) {
     width: maxX - minX,
     height: maxY - minY,
   };
-}
-
-// 判断两个点是否重合
-function isSamePoint(point1, point2) {
-  return point1[0] === point2[0] && point1[1] === point2[1];
 }
 
 // 获取 L segment 的外尖角与内夹角的距离 + 二分之一线宽

--- a/packages/g-canvas/src/util/util.ts
+++ b/packages/g-canvas/src/util/util.ts
@@ -57,6 +57,15 @@ export function mergeRegion(region1, region2) {
   };
 }
 
+/**
+ * 判断两个点是否重合，点坐标的格式为 [x, y]
+ * @param {Array} point1 第一个点
+ * @param {Array} point2 第二个点
+ */
+export function isSamePoint(point1, point2) {
+  return point1[0] === point2[0] && point1[1] === point2[1];
+}
+
 export { default as isNil } from '@antv/util/lib/is-nil';
 export { default as isString } from '@antv/util/lib/is-string';
 export { default as isFunction } from '@antv/util/lib/is-function';

--- a/packages/g-canvas/tests/bugs/issue-287-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-287-spec.js
@@ -1,0 +1,34 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#287', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 1000,
+    height: 1000,
+  });
+
+  it('should render correctly when start point and end point are same for arc', () => {
+    const path = canvas.addShape('path', {
+      attrs: {
+        stroke: '#444',
+        path: [
+          ['M', 711.9765625, 265],
+          ['L', 759.8580858439664, 86.30372213652237],
+          ['A', 185, 185, 0, 0, 1, 759.8580858439664, 86.30372213652237],
+          ['L', 711.9765625, 265],
+          ['Z'],
+        ],
+      },
+    });
+    const bbox = path.getBBox();
+    expect(bbox.minX).eqls(711.4765625);
+    expect(bbox.minY).eqls(85.80372213652237);
+    expect(bbox.maxX).eqls(760.3580858439664);
+    expect(bbox.maxY).eqls(265.5);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #287 and #292.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- The case of start point and end pointer should be considered.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix incorrect rendering for arc when start point and end point are same. #287 #292         |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复起点和终点相同时，弧形绘制不正确的问题。#287 #292         |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
