### PR TITLE
feat(g-canvas & g-svg): add getTotalLength method for path

### DIFF
--- a/docs/api/shape/api.en.md
+++ b/docs/api/shape/api.en.md
@@ -2,3 +2,21 @@
 title: API
 order: 4
 ---
+
+## 属性
+
+### 通用的 [元素属性](/en/docs/api/element#通用属性)
+
+### attrs: Object
+
+- 绘图属性，详见 [绘图属性](/en/docs/api/shape/attrs) 说明；
+
+## 方法
+
+### 通用的 [元素方法](/en/docs/api/element#通用方法)
+
+### isHit(x: number, y: number)
+
+### isClipShape()
+
+- 当前图形是否用于裁剪, 默认为 `false`；

--- a/docs/api/shape/path.en.md
+++ b/docs/api/shape/path.en.md
@@ -16,3 +16,11 @@ order: 12
 - 路径，支持 `字符串`和 `数组` 两种形式，详情可以参考 [SVG path](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Tutorial/Paths)。
   - 字符串形式: `M 100,100 L 200,200`
   - 数组形式: `[ [ 'M', 100, 100 ], [ 'L', 200, 200 ] ]`
+
+## Method
+
+### General [shape methods](/en/docs/api/shape#方法)
+
+### getTotalLength(): number
+
+- Get total length of path；

--- a/docs/api/shape/path.zh.md
+++ b/docs/api/shape/path.zh.md
@@ -16,3 +16,11 @@ order: 12
 - 路径，支持 `字符串`和 `数组` 两种形式，详情可以参考 [SVG path](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Tutorial/Paths)。
   - 字符串形式: `M 100,100 L 200,200`
   - 数组形式: `[ [ 'M', 100, 100 ], [ 'L', 200, 200 ] ]`
+
+## 方法
+
+### 通用的 [图形方法](/zh/docs/api/shape#方法)
+
+### getTotalLength(): number
+
+- 获取路径长度；

--- a/packages/g-base/src/index.ts
+++ b/packages/g-base/src/index.ts
@@ -3,6 +3,7 @@
  * @author dxq613@gmail.com
  */
 
+import * as PathUtil from './util/path';
 const pkg = require('../package.json');
 
 export const version = pkg.version;
@@ -11,3 +12,4 @@ export { default as Base } from './abstract/base';
 export { default as AbstractCanvas } from './abstract/canvas';
 export { default as AbstractGroup } from './abstract/group';
 export { default as AbstractShape } from './abstract/shape';
+export { PathUtil };

--- a/packages/g-base/src/util/path.ts
+++ b/packages/g-base/src/util/path.ts
@@ -148,7 +148,10 @@ const ellipsePath = function(x, y, rx, ry, a?) {
     const x2 = x + rx * Math.cos(-a * rad);
     const y1 = y + rx * Math.sin(-ry * rad);
     const y2 = y + rx * Math.sin(-a * rad);
-    res = [['M', x1, y1], ['A', rx, rx, 0, +(a - ry > 180), 0, x2, y2]];
+    res = [
+      ['M', x1, y1],
+      ['A', rx, rx, 0, +(a - ry > 180), 0, x2, y2],
+    ];
   } else {
     res = [['M', x, y], ['m', 0, -ry], ['a', rx, ry, 0, 1, 1, 0, 2 * ry], ['a', rx, ry, 0, 1, 1, 0, -2 * ry], ['z']];
   }
@@ -400,7 +403,7 @@ const a2c = function(x1, y1, rx, ry, angle, large_arc_flag, sweep_flag, x2, y2, 
   return newres;
 };
 
-const pathTocurve = function(path, path2?) {
+const pathToCurve = function(path, path2?) {
   const p = pathToAbsolute(path);
   const p2 = path2 && pathToAbsolute(path2);
   const attrs = {
@@ -909,8 +912,8 @@ const interHelper = function(bez1, bez2, justCount) {
 };
 
 const interPathHelper = function(path1, path2, justCount?) {
-  path1 = pathTocurve(path1);
-  path2 = pathTocurve(path2);
+  path1 = pathToCurve(path1);
+  path2 = pathToCurve(path2);
   let x1;
   let y1;
   let x2;
@@ -1380,6 +1383,6 @@ export {
   parsePathArray,
   parsePathString,
   pathToAbsolute,
-  pathTocurve,
+  pathToCurve,
   rectPath,
 };

--- a/packages/g-canvas/src/util/path.ts
+++ b/packages/g-canvas/src/util/path.ts
@@ -2,6 +2,7 @@
  * @fileoverview path 的一些工具
  * @author dxq613@gmail.com
  */
+import { PathUtil } from '@antv/g-base';
 import getArcParams from './arc-params';
 import QuadUtil from '@antv/g-math/lib/quadratic';
 import CubicUtil from '@antv/g-math/lib/cubic';
@@ -330,4 +331,5 @@ export default {
   getSegments,
   getPathBox,
   isPointInStroke,
+  ...PathUtil,
 };

--- a/packages/g-canvas/tests/unit/shape/path-spec.js
+++ b/packages/g-canvas/tests/unit/shape/path-spec.js
@@ -8,25 +8,48 @@ document.body.appendChild(canvas);
 const ctx = canvas.getContext('2d');
 
 describe('test path', () => {
-  const p1 = [['M', 10, 10], ['L', 20, 20]];
-  const p11 = [['M', 10, 10], ['L', 20, 10], ['L', 20, 20]];
-  const p2 = [['M', 10, 10], ['Q', 20, 20, 30, 10]];
+  const p1 = [
+    ['M', 10, 10],
+    ['L', 20, 20],
+  ];
+  const p11 = [
+    ['M', 10, 10],
+    ['L', 20, 10],
+    ['L', 20, 20],
+  ];
+  const p2 = [
+    ['M', 10, 10],
+    ['Q', 20, 20, 30, 10],
+  ];
 
-  const p3 = [['M', 10, 10], ['L', 20, 20], ['C', 30, 10, 40, 30, 50, 20]];
+  const p3 = [
+    ['M', 10, 10],
+    ['L', 20, 20],
+    ['C', 30, 10, 40, 30, 50, 20],
+  ];
   const p4 = [['M', 10, 10], ['L', 20, 20], ['A', 20, 20, 0, 0, 1, 60, 20], ['Z'], ['M', 200, 200], ['L', 300, 300]];
   const path = new Path({
     attrs: {
-      path: [['M', 10, 10], ['l', 2, 2]],
+      path: [
+        ['M', 10, 10],
+        ['l', 2, 2],
+      ],
       stroke: 'red',
     },
   });
   it('init', () => {
     expect(path.attr('stroke')).eqls('red');
     expect(path.attr('lineWidth')).eqls(1);
-    expect(path.attr('path')).eqls([['M', 10, 10], ['L', 12, 12]]);
+    expect(path.attr('path')).eqls([
+      ['M', 10, 10],
+      ['L', 12, 12],
+    ]);
     expect(path.get('hasArc')).eqls(false);
 
-    path.attr('path', [['M', 2, 2], ['Q', 3, 4, 4, 2, 5, 6]]);
+    path.attr('path', [
+      ['M', 2, 2],
+      ['Q', 3, 4, 4, 2, 5, 6],
+    ]);
     expect(path.get('hasArc')).eqls(true);
   });
 
@@ -174,5 +197,32 @@ describe('test path', () => {
       width: 290,
       height: 300,
     });
+  });
+
+  it('getTotalLength', () => {
+    path.attr('path', p1);
+    expect(path.getTotalLength()).eqls(14.142135623730951);
+    path.attr('path', p2);
+    expect(path.getTotalLength()).eqls(22.955857143237814);
+    path.attr('path', p3);
+    expect(path.getTotalLength()).eqls(46.891433122566326);
+    path.attr('path', p4);
+    expect(path.getTotalLength()).eqls(258.5855635430996);
+    path.attr(
+      'path',
+      'M 100,300' +
+        'l 50,-25' +
+        'a 25,25 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'a 25,50 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'a 25,75 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'a 25,100 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'l 0, 200,' +
+        'z'
+    );
+    expect(path.getTotalLength()).eqls(1577.9692907990257);
   });
 });

--- a/packages/g-svg/src/shape/path.ts
+++ b/packages/g-svg/src/shape/path.ts
@@ -40,6 +40,15 @@ class Path extends ShapeBase {
     }
     return newValue;
   }
+
+  /*
+   尽管通过浏览器的 SVGPathElement.getTotalLength() 接口获取的 path 长度，
+   与 Canvas 版本通过数学计算的方式得到的长度有一些细微差异，但最大误差在个位数像素，精度上可以能接受
+   */
+  getTotalLength() {
+    const el = this.get('el');
+    return el ? el.getTotalLength() : null;
+  }
 }
 
 export default Path;

--- a/packages/g-svg/tests/unit/shape/path-spec.js
+++ b/packages/g-svg/tests/unit/shape/path-spec.js
@@ -10,7 +10,10 @@ describe('SVG path', () => {
     canvas = getCanvas('svg-path');
     path = new Path({
       attrs: {
-        path: [['M', 100, 100], ['L', 200, 200]],
+        path: [
+          ['M', 100, 100],
+          ['L', 200, 200],
+        ],
         lineWidth: 1,
         stroke: 'red',
         startArrow: {
@@ -23,7 +26,10 @@ describe('SVG path', () => {
   });
 
   it('init', () => {
-    expect(path.attr('path')).eql([['M', 100, 100], ['L', 200, 200]]);
+    expect(path.attr('path')).eql([
+      ['M', 100, 100],
+      ['L', 200, 200],
+    ]);
     expect(path.attr('lineWidth')).eql(1);
     expect(path.attr('stroke')).eql('red');
     expect(path.attr('startArrow')).eql({
@@ -55,8 +61,16 @@ describe('SVG path', () => {
   });
 
   it('change', () => {
-    path.attr('path', [['M', 100, 100], ['L', 200, 200], ['L', 300, 300]]);
-    expect(path.attr('path')).eql([['M', 100, 100], ['L', 200, 200], ['L', 300, 300]]);
+    path.attr('path', [
+      ['M', 100, 100],
+      ['L', 200, 200],
+      ['L', 300, 300],
+    ]);
+    expect(path.attr('path')).eql([
+      ['M', 100, 100],
+      ['L', 200, 200],
+      ['L', 300, 300],
+    ]);
     const bbox = path.getBBox();
     expect(bbox.minX).eql(99.5);
     expect(bbox.minY).eql(99.5);
@@ -68,6 +82,51 @@ describe('SVG path', () => {
     expect(path.isHit(300, 300)).eql(true);
     expect(path.isHit(400, 400)).eql(false);
     expect(path.isHit(150, 100)).eql(false);
+  });
+
+  it('getTotalLength', () => {
+    const p1 = [
+      ['M', 10, 10],
+      ['L', 20, 20],
+    ];
+    const p2 = [
+      ['M', 10, 10],
+      ['Q', 20, 20, 30, 10],
+    ];
+    const p3 = [
+      ['M', 10, 10],
+      ['L', 20, 20],
+      ['C', 30, 10, 40, 30, 50, 20],
+    ];
+    const p4 = [['M', 10, 10], ['L', 20, 20], ['A', 20, 20, 0, 0, 1, 60, 20], ['Z'], ['M', 200, 200], ['L', 300, 300]];
+
+    path.attr('path', p1);
+    expect(path.getTotalLength()).eqls(14.142135620117188);
+    path.attr('path', p2);
+    expect(path.getTotalLength()).eqls(22.95588493347168);
+    path.attr('path', p3);
+    expect(path.getTotalLength()).eqls(46.89018630981445);
+    path.attr('path', p4);
+    // TODO: 这个 case 与 Canavs 的计算结果误差较大，问题原因待排查
+    // Canvas 版本
+    // expect(path.getTotalLength()).eqls(258.5855635430996);
+    expect(path.getTotalLength()).eqls(269.3943786621094);
+    path.attr(
+      'path',
+      'M 100,300' +
+        'l 50,-25' +
+        'a 25,25 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'a 25,50 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'a 25,75 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'a 25,100 -30 0,1 50,-25' +
+        'l 50,-25' +
+        'l 0, 200,' +
+        'z'
+    );
+    expect(path.getTotalLength()).eqls(1579.16943359375);
   });
 
   it('destroy', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref #295.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🌟 [g-canvas & g-svg] Add `getTotalLength()` method for Path. #295          |
| 🇨🇳 Chinese | 🌟 [g-canvas & g-svg] Path 上新增 `getTotalLength()` 成员方法。#295          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
