### PR TITLE
fix(g-canvas): partial rendering for arc path should be correct when rx or ry is 0

### DIFF
--- a/packages/g-base/src/event/graph-event.ts
+++ b/packages/g-base/src/event/graph-event.ts
@@ -92,7 +92,7 @@ class GraphEvent {
    * 触发时的对象
    * @type {object}
    */
-  domEvent: Event;
+  originalEvent: Event;
 
   // 触发事件的路径
   propagationPath: any[] = [];
@@ -100,7 +100,7 @@ class GraphEvent {
   constructor(type, event) {
     this.type = type;
     this.name = type;
-    this.domEvent = event;
+    this.originalEvent = event;
     this.timeStamp = event.timeStamp;
   }
 
@@ -109,7 +109,9 @@ class GraphEvent {
    */
   preventDefault() {
     this.defaultPrevented = true;
-    this.domEvent.preventDefault();
+    if (this.originalEvent.preventDefault) {
+      this.originalEvent.preventDefault();
+    }
   }
 
   /**

--- a/packages/g-base/tests/unit/event-spec.js
+++ b/packages/g-base/tests/unit/event-spec.js
@@ -75,7 +75,7 @@ describe('test event object', () => {
   const event = new GraphEvent('custom', mockEvent);
   it('init', () => {
     expect(event.type).eql('custom');
-    expect(event.domEvent).eql(mockEvent);
+    expect(event.originalEvent).eql(mockEvent);
     expect(event.propagationStopped).eql(false);
   });
 

--- a/packages/g-canvas/src/util/arc-params.ts
+++ b/packages/g-canvas/src/util/arc-params.ts
@@ -48,9 +48,9 @@ export default function getArcParams(startPoint, params) {
     f = 0;
   }
 
-  // 旋转前的起点坐标
-  const cxp = (f * rx * yp) / ry;
-  const cyp = (f * -ry * xp) / rx;
+  // 旋转前的起点坐标，且当长半轴和短半轴的长度为 0 时，坐标按 (0, 0) 处理
+  const cxp = ry ? (f * rx * yp) / ry : 0;
+  const cyp = rx ? (f * -ry * xp) / rx : 0;
 
   // 椭圆圆心坐标
   const cx = (x1 + x2) / 2.0 + Math.cos(xRotation) * cxp - Math.sin(xRotation) * cyp;

--- a/packages/g-canvas/tests/bugs/issue-326-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-326-spec.js
@@ -1,0 +1,64 @@
+// const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+// import { getColor } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#323', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+    pixelRatio: 1,
+  });
+
+  function distance(p1, p2) {
+    const dx = p2.x - p1.x;
+    const dy = p2.y - p1.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  function getPath(start, end) {
+    const path = [];
+    path.push(['M', start.x, start.y]);
+    const r = distance(start, end);
+    path.push(['M', start.x, start.y]);
+    path.push(['A', r, r, 0, 0, 0, end.x, end.y]);
+    path.push(['A', r, r, 0, 0, 0, start.x, start.y]);
+    path.push(['Z']);
+    return path;
+  }
+
+  const shape = canvas.addShape({
+    type: 'path',
+    attrs: {
+      fill: 'red',
+      path: [],
+    },
+  });
+  let start;
+  canvas.on('mousedown', (ev) => {
+    start = {
+      x: ev.x,
+      y: ev.y,
+    };
+  });
+
+  canvas.on('mousemove', (ev) => {
+    if (start) {
+      const current = {
+        x: ev.x,
+        y: ev.y,
+      };
+      shape.attr('path', getPath(start, current));
+    }
+  });
+
+  canvas.on('mouseup', () => {
+    start = null;
+  });
+
+  it('test', () => {});
+});

--- a/packages/g-canvas/tests/bugs/issue-326-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-326-spec.js
@@ -1,12 +1,30 @@
-// const expect = require('chai').expect;
+const expect = require('chai').expect;
 import Canvas from '../../src/canvas';
-// import { getColor } from '../get-color';
+import { getColor } from '../get-color';
+import { getClientPoint, simulateMouseEvent } from '../util';
 
 const dom = document.createElement('div');
 document.body.appendChild(dom);
 dom.id = 'c1';
 
-describe('#323', () => {
+function distance(p1, p2) {
+  const dx = p2.x - p1.x;
+  const dy = p2.y - p1.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function getPath(start, end) {
+  const path = [];
+  path.push(['M', start.x, start.y]);
+  const r = distance(start, end);
+  path.push(['M', start.x, start.y]);
+  path.push(['A', r, r, 0, 0, 0, end.x, end.y]);
+  path.push(['A', r, r, 0, 0, 0, start.x, start.y]);
+  path.push(['Z']);
+  return path;
+}
+
+describe('#326', () => {
   const canvas = new Canvas({
     container: dom,
     width: 600,
@@ -14,51 +32,71 @@ describe('#323', () => {
     pixelRatio: 1,
   });
 
-  function distance(p1, p2) {
-    const dx = p2.x - p1.x;
-    const dy = p2.y - p1.y;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
+  const context = canvas.get('context');
+  const el = canvas.get('el');
 
-  function getPath(start, end) {
-    const path = [];
-    path.push(['M', start.x, start.y]);
-    const r = distance(start, end);
-    path.push(['M', start.x, start.y]);
-    path.push(['A', r, r, 0, 0, 0, end.x, end.y]);
-    path.push(['A', r, r, 0, 0, 0, start.x, start.y]);
-    path.push(['Z']);
-    return path;
-  }
-
-  const shape = canvas.addShape({
-    type: 'path',
-    attrs: {
-      fill: 'red',
-      path: [],
-    },
-  });
-  let start;
-  canvas.on('mousedown', (ev) => {
-    start = {
-      x: ev.x,
-      y: ev.y,
-    };
-  });
-
-  canvas.on('mousemove', (ev) => {
-    if (start) {
-      const current = {
+  it('partial rendering for arc path should be correct when rx or ry is 0', () => {
+    const shape = canvas.addShape({
+      type: 'path',
+      attrs: {
+        fill: 'red',
+        path: [],
+      },
+    });
+    let start;
+    canvas.on('mousedown', (ev) => {
+      start = {
         x: ev.x,
         y: ev.y,
       };
-      shape.attr('path', getPath(start, current));
-    }
-  });
+    });
 
-  canvas.on('mouseup', () => {
-    start = null;
-  });
+    canvas.on('mousemove', (ev) => {
+      if (start) {
+        const current = {
+          x: ev.x,
+          y: ev.y,
+        };
+        shape.attr('path', getPath(start, current));
+      }
+    });
 
-  it('test', () => {});
+    canvas.on('mouseup', () => {
+      start = null;
+    });
+
+    const { clientX, clientY } = getClientPoint(canvas, 10, 10);
+    simulateMouseEvent(el, 'mousedown', {
+      clientX,
+      clientY,
+    });
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 100,
+      clientY: clientY + 100,
+    });
+    simulateMouseEvent(el, 'mouseup', {
+      clientX: clientX + 100,
+      clientY: clientY + 100,
+    });
+    setTimeout(() => {
+      expect(getColor(context, 50, 50)).eqls('#ff0000');
+      expect(getColor(context, 50, 150)).eqls('#000000');
+    }, 0);
+    simulateMouseEvent(el, 'mousedown', {
+      clientX,
+      clientY: clientY + 110,
+    });
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 100,
+      clientY: clientY + 110 + 100,
+    });
+    simulateMouseEvent(el, 'mouseup', {
+      clientX: clientX + 100,
+      clientY: clientY + 110 + 100,
+    });
+    setTimeout(() => {
+      expect(getColor(context, 50, 50)).eqls('#000000');
+      expect(getColor(context, 50, 150)).eqls('#ff0000');
+    }, 0);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #326.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 另外，还将事件对象上的 `domEvent` 重命名为 `originalEvent`，以兼容自定义事件。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix incorrect `partial rendering` for `arc path` when `rx` or `ry` is 0. #323          |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复 `弧形 path` 在长轴和短轴长度为 0 时，局部渲染不正确的问题。#323         |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
