### PR TITLE
fix(module): add module entry to avoid jest sourcemap is empty

### DIFF
--- a/packages/g-base/package.json
+++ b/packages/g-base/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.2",
   "description": "A common util collection for antv projects",
   "main": "lib/index.js",
+  "module": "esm/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "package.json",

--- a/packages/g-math/package.json
+++ b/packages/g-math/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "geometry math",
   "main": "lib/index.js",
+  "module": "esm/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "package.json",


### PR DESCRIPTION
 - [x] 上层 Component 调试的时候，发现 sourcemap 一直为空，增加 module 之后测试是 ok 的。