### PR TITLE
fix(g-base): sort method should work when zIndex is changed

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -98,6 +98,7 @@ abstract class Element extends Base implements IElement {
     return {
       visible: true,
       capture: true,
+      zIndex: 0,
     };
   }
 

--- a/packages/g-canvas/tests/bugs/issue-339-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-339-spec.js
@@ -1,0 +1,51 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { getColor } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#339', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+    pixelRatio: 1,
+  });
+  const context = canvas.get('context');
+
+  it('sort method should work when zIndex is changed', (done) => {
+    const group = canvas.addGroup();
+    const rect = group.addShape('rect', {
+      attrs: {
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100,
+        fill: 'red',
+      },
+    });
+
+    group.addShape('circle', {
+      attrs: {
+        x: 150,
+        y: 150,
+        r: 60,
+        fill: 'blue',
+      },
+    });
+    // rect is behind of circle
+    setTimeout(() => {
+      expect(getColor(context, 150, 150)).eqls('#0000ff');
+
+      rect.set('zIndex', 1);
+      group.sort();
+      // rect is front of circle
+      setTimeout(() => {
+        expect(getColor(context, 150, 150)).eqls('#ff0000');
+        done();
+      }, 25);
+    }, 25);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #339.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix that `sort()` method doesn't work when `zIndex` is changed. #339         |
| 🇨🇳 Chinese | 🐞 [g-base] 修复当子元素的 `zIndex` 改变时，容器的 `sort()` 方法不生效的问题。#339          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
