### PR TITLE
fix(g-canvas & g-svg): opacity attr for shape should be 1 by default

### DIFF
--- a/docs/api/shape/attrs.en.md
+++ b/docs/api/shape/attrs.en.md
@@ -7,70 +7,78 @@ order: 5
 
 ### fill
 
-- 设置用于填充绘画的颜色、[渐变](/en/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
+- 填充色、[渐变](/zh/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
 
 ### stroke
 
-- 设置用于填充绘画的颜色、[渐变](/en/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
-
-### shadowColor
-
-- 设置用于阴影的颜色；
-
-### shadowBlur
-
-- 设置用于阴影的模糊级别；
-
-### shadowOffsetX
-
-- 设置阴影距形状的水平距离；
-
-### shadowOffsetY
-
-- 设置阴影距形状的垂直距离；
+- 描边色、[渐变](/zh/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
 
 ### opacity
 
-- 设置绘图的当前 alpha 或透明值；
+- 透明度，默认值为 1；
+
+### fillOpacity
+
+- 填充色的不透明度，默认值为 1；
+
+### strokeOpacity
+
+- 描边色的不透明度，默认值为 1；
+
+### shadowColor
+
+- 阴影的颜色；
+
+### shadowBlur
+
+- 阴影的模糊级别；
+
+### shadowOffsetX
+
+- 阴影距形状的水平距离；
+
+### shadowOffsetY
+
+- 阴影距形状的垂直距离；
 
 ### globalCompositeOperation
 
-- 设置新图像如何绘制到已有的图像上；
+- 新图像如何绘制到已有的图像上；
 
 ## 线条属性
 
 ### lineCap
 
-- 设置线条的结束端点样式；
+- 线条的结束端点样式；
 
 ### lineJoin
 
-- 设置两条线相交时，所创建的拐角形状，属性值有:
+- 两条线相交时，所创建的拐角形状，属性值有:
   - `bevel`: 斜角
   - `round`: 圆角
   - `miter`: 尖角 (默认)
 
 ### lineWidth
 
-- 设置当前的线条宽度，默认值为 1；
+- 当前的线条宽度，默认值为 1；
 
 ### lineAppendWidth
 
-- 设置额外的线条宽度，且不可见，常用于增加图形的可拾取区域，默认值为 0；
+- 额外的线条宽度，且不可见，常用于增加图形的可拾取区域，默认值为 0；
 
 ### miterLimit
 
-- 设置最大斜接长度；
+- 最大斜接长度；
 
 ### lineDash
 
 > 这个属性取决于浏览器是否支持 setLineDash 函数，详情参考 [setLineDash](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)。
 
-- 设置线的虚线样式，可以指定一个数组。一组描述交替绘制线段和间距（坐标空间单位）长度的数字。 如果数组元素的数量是奇数， 数组的元素会被复制并重复。例如， [5, 15, 25] 会变成 [5, 15, 25, 5, 15, 25]。
+- 线的虚线样式，可以指定一个数组。一组描述交替绘制线段和间距（坐标空间单位）长度的数字。 如果数组元素的数量是奇数， 数组的元素会被复制并重复。例如， [5, 15, 25] 会变成 [5, 15, 25, 5, 15, 25]。
 
 ### startArrow
 
-- 设置起点箭头，值的类型为 `boolean | ArrowCfg | Marker`：
+- 起点箭头，值的类型为 `boolean | ArrowCfg | Marker`：
 
   - `true / false`: 显示 / 取消默认箭头；
   - `ArrowCfg`: 自定义箭头，具体配置为:
@@ -94,49 +102,49 @@ order: 5
 
 ### endArrow
 
-- 设置终点箭头，配置同 [startArrow](#startarrow)。
+- 终点箭头，配置同 [startArrow](#startarrow)。
 
 ## 文本属性
 
 ### font
 
-- 设置文本内容的当前字体属性；
+- 文本内容的当前字体属性；
 
 ### textAlign
 
-- 设置文本内容的当前对齐方式, 支持的属性值：
+- 文本内容的对齐方式, 支持的属性值：
   - center
   - end
   - left
   - right
-  - start
+  - start (默认)
 
 ### textBaseline
 
-- 设置在绘制文本时使用的当前文本基线, 支持的属性：
+- 绘制文本时的基线, 支持的属性值：
   - top
   - middle
-  - bottom
+  - bottom (默认)
 
 ### fontStyle
 
-- 设置字体样式；
+- 字体样式；
 
 ### fontVariant
 
-- 设置小型大写字母的字体显示文本；
+- 小型大写字母的字体显示文本；
 
 ### fontWeight
 
-- 设置字体粗细；
+- 字体粗细；
 
 ### fontSize
 
-- 设置字体尺寸；
+- 字体尺寸，默认值为 `12`；
 
 ### fontFamily
 
-- 设置字体类型；
+- 字体类型，默认值为 `sans-serif`；
 
 ## 渐变色
 

--- a/docs/api/shape/attrs.zh.md
+++ b/docs/api/shape/attrs.zh.md
@@ -7,70 +7,78 @@ order: 5
 
 ### fill
 
-- 设置用于填充绘画的颜色、[渐变](/zh/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
+- 填充色、[渐变](/zh/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
 
 ### stroke
 
-- 设置用于填充绘画的颜色、[渐变](/zh/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
-
-### shadowColor
-
-- 设置用于阴影的颜色；
-
-### shadowBlur
-
-- 设置用于阴影的模糊级别；
-
-### shadowOffsetX
-
-- 设置阴影距形状的水平距离；
-
-### shadowOffsetY
-
-- 设置阴影距形状的垂直距离；
+- 描边色、[渐变](/zh/docs/api/shape/attrs/#渐变色)或 [纹理](/zh/docs/api/shape/attrs/#纹理)，默认值为空；
 
 ### opacity
 
-- 设置绘图的当前 alpha 或透明值；
+- 透明度，默认值为 1；
+
+### fillOpacity
+
+- 填充色的不透明度，默认值为 1；
+
+### strokeOpacity
+
+- 描边色的不透明度，默认值为 1；
+
+### shadowColor
+
+- 阴影的颜色；
+
+### shadowBlur
+
+- 阴影的模糊级别；
+
+### shadowOffsetX
+
+- 阴影距形状的水平距离；
+
+### shadowOffsetY
+
+- 阴影距形状的垂直距离；
 
 ### globalCompositeOperation
 
-- 设置新图像如何绘制到已有的图像上；
+- 新图像如何绘制到已有的图像上；
 
 ## 线条属性
 
 ### lineCap
 
-- 设置线条的结束端点样式；
+- 线条的结束端点样式；
 
 ### lineJoin
 
-- 设置两条线相交时，所创建的拐角形状，属性值有:
+- 两条线相交时，所创建的拐角形状，属性值有:
   - `bevel`: 斜角
   - `round`: 圆角
   - `miter`: 尖角 (默认)
 
 ### lineWidth
 
-- 设置当前的线条宽度，默认值为 1；
+- 当前的线条宽度，默认值为 1；
 
 ### lineAppendWidth
 
-- 设置额外的线条宽度，且不可见，常用于增加图形的可拾取区域，默认值为 0；
+- 额外的线条宽度，且不可见，常用于增加图形的可拾取区域，默认值为 0；
 
 ### miterLimit
 
-- 设置最大斜接长度；
+- 最大斜接长度；
 
 ### lineDash
 
 > 这个属性取决于浏览器是否支持 setLineDash 函数，详情参考 [setLineDash](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)。
 
-- 设置线的虚线样式，可以指定一个数组。一组描述交替绘制线段和间距（坐标空间单位）长度的数字。 如果数组元素的数量是奇数， 数组的元素会被复制并重复。例如， [5, 15, 25] 会变成 [5, 15, 25, 5, 15, 25]。
+- 线的虚线样式，可以指定一个数组。一组描述交替绘制线段和间距（坐标空间单位）长度的数字。 如果数组元素的数量是奇数， 数组的元素会被复制并重复。例如， [5, 15, 25] 会变成 [5, 15, 25, 5, 15, 25]。
 
 ### startArrow
 
-- 设置起点箭头，值的类型为 `boolean | ArrowCfg | Marker`：
+- 起点箭头，值的类型为 `boolean | ArrowCfg | Marker`：
 
   - `true / false`: 显示 / 取消默认箭头；
   - `ArrowCfg`: 自定义箭头，具体配置为:
@@ -94,49 +102,49 @@ order: 5
 
 ### endArrow
 
-- 设置终点箭头，配置同 [startArrow](#startarrow)。
+- 终点箭头，配置同 [startArrow](#startarrow)。
 
 ## 文本属性
 
 ### font
 
-- 设置文本内容的当前字体属性；
+- 文本内容的当前字体属性；
 
 ### textAlign
 
-- 设置文本内容的当前对齐方式, 支持的属性值：
+- 文本内容的对齐方式, 支持的属性值：
   - center
   - end
   - left
   - right
-  - start
+  - start (默认)
 
 ### textBaseline
 
-- 设置在绘制文本时使用的当前文本基线, 支持的属性：
+- 绘制文本时的基线, 支持的属性值：
   - top
   - middle
-  - bottom
+  - bottom (默认)
 
 ### fontStyle
 
-- 设置字体样式；
+- 字体样式；
 
 ### fontVariant
 
-- 设置小型大写字母的字体显示文本；
+- 小型大写字母的字体显示文本；
 
 ### fontWeight
 
-- 设置字体粗细；
+- 字体粗细；
 
 ### fontSize
 
-- 设置字体尺寸；
+- 字体尺寸，默认值为 `12`；
 
 ### fontFamily
 
-- 设置字体类型；
+- 字体类型，默认值为 `sans-serif`；
 
 ## 渐变色
 

--- a/packages/g-canvas/src/shape/base.ts
+++ b/packages/g-canvas/src/shape/base.ts
@@ -10,11 +10,14 @@ class ShapeBase extends AbstractShape {
   getDefaultAttrs() {
     const attrs = super.getDefaultAttrs();
     // 设置默认值
-    attrs['lineWidth'] = 1;
-    attrs['lineAppendWidth'] = 0;
-    attrs['strokeOpacity'] = 1;
-    attrs['fillOpacity'] = 1;
-    return attrs;
+    return {
+      ...attrs,
+      lineWidth: 1,
+      lineAppendWidth: 0,
+      opacity: 1,
+      strokeOpacity: 1,
+      fillOpacity: 1,
+    };
   }
 
   getShapeBase() {
@@ -151,24 +154,20 @@ class ShapeBase extends AbstractShape {
 
   // 绘制或者填充
   strokeAndFill(context) {
-    const attrs = this.attrs;
-    const originOpacity = context.globalAlpha;
+    const { lineWidth, opacity, strokeOpacity, fillOpacity } = this.attrs;
 
     if (this.isFill()) {
-      const fillOpacity = attrs['fillOpacity'];
       if (!isNil(fillOpacity) && fillOpacity !== 1) {
         context.globalAlpha = fillOpacity;
         this.fill(context);
-        context.globalAlpha = originOpacity;
+        context.globalAlpha = opacity;
       } else {
         this.fill(context);
       }
     }
 
     if (this.isStroke()) {
-      const lineWidth = attrs['lineWidth'];
       if (lineWidth > 0) {
-        const strokeOpacity = attrs['strokeOpacity'];
         if (!isNil(strokeOpacity) && strokeOpacity !== 1) {
           context.globalAlpha = strokeOpacity;
         }

--- a/packages/g-canvas/src/shape/image.ts
+++ b/packages/g-canvas/src/shape/image.ts
@@ -14,12 +14,6 @@ class ImageShape extends ShapeBase {
     this._setImage(attrs.img);
   }
 
-  // image 不需要默认的边框等属性
-  getDefaultAttrs() {
-    return {
-      matrix: null,
-    };
-  }
   // image 不计算 stroke
   isStroke() {
     return false;

--- a/packages/g-canvas/src/shape/text.ts
+++ b/packages/g-canvas/src/shape/text.ts
@@ -10,10 +10,9 @@ import { isNil, isString, each, getOffScreenContext } from '../util/util';
 class Text extends ShapeBase {
   // 默认文本属性
   getDefaultAttrs() {
+    const attrs = super.getDefaultAttrs();
     return {
-      matrix: null,
-      lineWidth: 1,
-      lineAppendWidth: 0,
+      ...attrs,
       fontSize: 12,
       fontFamily: 'sans-serif',
       fontStyle: 'normal',
@@ -220,26 +219,22 @@ class Text extends ShapeBase {
 
   // 复写绘制和填充的逻辑：对于文本，应该先绘制边框，再进行填充
   strokeAndFill(context) {
-    const attrs = this.attrs;
-    const originOpacity = context.globalAlpha;
+    const { lineWidth, opacity, strokeOpacity, fillOpacity } = this.attrs;
 
     if (this.isStroke()) {
-      const lineWidth = attrs['lineWidth'];
       if (lineWidth > 0) {
-        const strokeOpacity = attrs['strokeOpacity'];
         if (!isNil(strokeOpacity) && strokeOpacity !== 1) {
-          context.globalAlpha = strokeOpacity;
+          context.globalAlpha = opacity;
         }
         this.stroke(context);
       }
     }
 
     if (this.isFill()) {
-      const fillOpacity = attrs['fillOpacity'];
       if (!isNil(fillOpacity) && fillOpacity !== 1) {
         context.globalAlpha = fillOpacity;
         this.fill(context);
-        context.globalAlpha = originOpacity;
+        context.globalAlpha = opacity;
       } else {
         this.fill(context);
       }

--- a/packages/g-canvas/tests/bugs/issue-342-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-342-spec.js
@@ -1,0 +1,29 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#342', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+  });
+
+  it('opacity attr for shape should be 1 by default', () => {
+    const rect = canvas.addShape('rect', {
+      attrs: {
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100,
+        fill: 'red',
+      },
+    });
+    expect(rect.attr('opacity')).eqls(1);
+    rect.attr('opacity', 0.8);
+    expect(rect.attr('opacity')).eqls(0.8);
+  });
+});

--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -17,11 +17,14 @@ class ShapeBase extends AbstractShape implements IShape {
   getDefaultAttrs() {
     const attrs = super.getDefaultAttrs();
     // 设置默认值
-    attrs['lineWidth'] = 1;
-    attrs['lineAppendWidth'] = 0;
-    attrs['strokeOpacity'] = 1;
-    attrs['fillOpacity'] = 1;
-    return attrs;
+    return {
+      ...attrs,
+      lineWidth: 1,
+      lineAppendWidth: 0,
+      opacity: 1,
+      strokeOpacity: 1,
+      fillOpacity: 1,
+    };
   }
 
   // 覆盖基类的 afterAttrsChange 方法

--- a/packages/g-svg/src/shape/rect.ts
+++ b/packages/g-svg/src/shape/rect.ts
@@ -14,9 +14,11 @@ class Rect extends ShapeBase {
 
   getDefaultAttrs() {
     const attrs = super.getDefaultAttrs();
-    // 设置默认值
-    attrs['radius'] = 0;
-    return attrs;
+    return {
+      ...attrs,
+      // 设置圆角的默认值为 0
+      radius: 0,
+    };
   }
 
   createPath(context, targetAttrs) {

--- a/packages/g-svg/tests/bugs/issue-342-spec.js
+++ b/packages/g-svg/tests/bugs/issue-342-spec.js
@@ -1,0 +1,29 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#342', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 600,
+    height: 600,
+  });
+
+  it('opacity attr for shape should be 1 by default', () => {
+    const rect = canvas.addShape('rect', {
+      attrs: {
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100,
+        fill: 'red',
+      },
+    });
+    expect(rect.attr('opacity')).eqls(1);
+    rect.attr('opacity', 0.8);
+    expect(rect.attr('opacity')).eqls(0.8);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #342.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas & g-svg] Fix that `opacity` attr for shape is `undefined` by default. #342  |
| 🇨🇳 Chinese | 🐞 [g-canvas & g-svg] 修复图形的 `opacity` 属性默认为空的问题。#342          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
