### PR TITLE
fix(canvas): canvas.getPointByClient() should calculate correctly when container has CSS transform

### DIFF
--- a/src/util/index.js
+++ b/src/util/index.js
@@ -26,6 +26,9 @@ CommonUtil.merge(Util, CommonUtil, {
       });
       c[Param] = Util.merge(temp, c[Param]);
     }
+  },
+  toNumber(value) {
+    return +value;
   }
 });
 

--- a/test/bugs/issue-333-spec.js
+++ b/test/bugs/issue-333-spec.js
@@ -1,0 +1,43 @@
+const expect = require('chai').expect;
+const Canvas = require('../../src/canvas');
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+dom.style.transform = 'scale(0.8, 0.8)';
+
+describe('#333', () => {
+  const canvas = new Canvas({
+    containerId: 'c1',
+    width: 600,
+    height: 600
+  });
+
+  it('canvas.getPointByClient() should calculate correctly when container has CSS transform', () => {
+    const group = canvas.addGroup();
+    const circle = group.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 100,
+        fill: 'red'
+      }
+    });
+
+    canvas.draw();
+
+    const { x: clientX } = canvas.getPointByClient(400, 400);
+    // 这里只判断 clientX 的值即可，因为 clientY 在 interactive 测试模式下，测试信息会占据一部分高度，导致和 renderer 模式下测试结果不一致的情况
+    expect(clientX).eqls(640);
+
+    circle.on('mouseenter', () => {
+      circle.attr('fill', 'blue');
+      canvas.draw();
+    });
+
+    circle.on('mouseleave', () => {
+      circle.attr('fill', 'red');
+      canvas.draw();
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #333.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 在 3.x 只简单处理 `scale` transform 函数，处理其他 transform 函数的完整方案将在 4.x 中实现。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix that canvas.getPointByClient() calculates incorrectly when container has CSS transform. #333          |
| 🇨🇳 Chinese | 🐞 修复当画布容器设置了 CSS transform 样式时，`canvas.getPointByClient()` 函数计算不正确的问题。#333          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
