### PR TITLE
fix(g-base): mouseup and click event should not be emitted when contextmenu emitted

### DIFF
--- a/packages/g-canvas/tests/bugs/issue-370-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-370-spec.js
@@ -1,0 +1,63 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { simulateMouseEvent, getClientPoint } from '../util';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#370', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+  });
+
+  const el = canvas.get('el');
+
+  it('mouseup and click event should not be emitted when contextmenu emitted', () => {
+    const circle = canvas.addShape('circle', {
+      attrs: {
+        x: 50,
+        y: 50,
+        r: 30,
+        fill: 'red',
+      },
+    });
+    let contextmenuCalled = false;
+    let clickCalled = false;
+    // 由于 simulateMouseEvent 模拟的 contextmenu 事件不会触发 mousedown，因此将 mousedown 相关的测试代码进行了注释
+    // 要想查看实际测试效果，可以在 interactive 模式下手动触发 contextmenu 事件进行测试
+    // let mousedownCalled = false;
+    let mouseupCalled = false;
+
+    circle.on('contextmenu', () => {
+      contextmenuCalled = true;
+    });
+
+    circle.on('click', () => {
+      clickCalled = true;
+    });
+
+    // circle.on('mousedown', () => {
+    //   console.log('mousedown')
+    //   mousedownCalled = true;
+    // });
+
+    circle.on('mouseup', () => {
+      mouseupCalled = true;
+    });
+
+    const { clientX, clientY } = getClientPoint(canvas, 30, 30);
+
+    simulateMouseEvent(el, 'contextmenu', {
+      clientX,
+      clientY,
+    });
+
+    expect(contextmenuCalled).eqls(true);
+    // expect(mousedownCalled).eqls(true);
+    expect(clickCalled).eqls(false);
+    expect(mouseupCalled).eqls(false);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #370.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix that `mouseup` and `click` event is emitted when `contextmenu` emitted. #370       |
| 🇨🇳 Chinese | 🐞 [g-base] 修复 `contextmenu` 事件会触发 `mouseup` 和 `click` 事件的问题。#370          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
