### PR TITLE
fix(g-canvas): opacity attr should be composite with parent

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -109,6 +109,7 @@ abstract class Element extends Base implements IElement {
   getDefaultAttrs() {
     return {
       matrix: this.getDefaultMatrix(),
+      opacity: 1,
     };
   }
 

--- a/packages/g-canvas/src/canvas.ts
+++ b/packages/g-canvas/src/canvas.ts
@@ -26,9 +26,13 @@ class Canvas extends AbstractCanvas {
    * @param {ChangeType} changeType 改变的类型
    */
   onCanvasChange(changeType: ChangeType) {
-    // 排序时图形的层次发生变化，
-    // 画布大小改变可能也会引起变化
-    if (changeType === 'sort' || changeType === 'changeSize') {
+    /**
+     * 触发画布更新的三种 changeType
+     * 1. attr: 修改画布的绘图属性
+     * 2. sort: 画布排序，图形的层次会发生变化
+     * 3. changeSize: 改变画布大小
+     */
+    if (changeType === 'attr' || changeType === 'sort' || changeType === 'changeSize') {
       this.set('refreshElements', [this]);
       this.draw();
     }

--- a/packages/g-canvas/src/shape/base.ts
+++ b/packages/g-canvas/src/shape/base.ts
@@ -14,7 +14,6 @@ class ShapeBase extends AbstractShape {
       ...attrs,
       lineWidth: 1,
       lineAppendWidth: 0,
-      opacity: 1,
       strokeOpacity: 1,
       fillOpacity: 1,
     };

--- a/packages/g-canvas/src/util/draw.ts
+++ b/packages/g-canvas/src/util/draw.ts
@@ -29,6 +29,9 @@ export function applyAttrsToContext(context: CanvasRenderingContext2D, element: 
         // 如果存在渐变、pattern 这个开销有些大
         // 可以考虑缓存机制，通过 hasUpdate 来避免一些运算
         v = parseStyle(context, element, v);
+      } else if (name === 'globalAlpha') {
+        // opacity 效果可以叠加，子元素的 opacity 需要与父元素 opacity 相乘
+        v = v * context.globalAlpha;
       }
       context[name] = v;
     }

--- a/packages/g-canvas/tests/bugs/issue-358-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-358-spec.js
@@ -1,0 +1,93 @@
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+/* TODO: Need a way to test composite opacity */
+describe('#358', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+  });
+
+  it('opacity attr should be composite with parent', () => {
+    const group = canvas.addGroup();
+    group.addShape({
+      type: 'circle',
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 20,
+        fill: 'red',
+        opacity: 0.1,
+      },
+    });
+
+    group.attr({
+      opacity: 0,
+    });
+
+    group.animate(
+      {
+        opacity: 1,
+      },
+      {
+        duration: 500,
+      }
+    );
+  });
+
+  it('opacity attr should be composite with ancestor', () => {
+    const group = canvas.addGroup();
+    const subGroup = group.addGroup();
+    subGroup.addShape({
+      type: 'circle',
+      attrs: {
+        x: 200,
+        y: 100,
+        r: 20,
+        fill: 'red',
+      },
+    });
+
+    group.attr({
+      opacity: 0,
+    });
+
+    group.animate(
+      {
+        opacity: 1,
+      },
+      {
+        duration: 500,
+      }
+    );
+  });
+
+  it('opacity attr should be composite with canvas', () => {
+    canvas.addShape({
+      type: 'circle',
+      attrs: {
+        x: 300,
+        y: 100,
+        r: 20,
+        fill: 'red',
+      },
+    });
+
+    canvas.attr({
+      opacity: 0,
+    });
+
+    canvas.animate(
+      {
+        opacity: 1,
+      },
+      {
+        duration: 500,
+      }
+    );
+  });
+});

--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -21,7 +21,6 @@ class ShapeBase extends AbstractShape implements IShape {
       ...attrs,
       lineWidth: 1,
       lineAppendWidth: 0,
-      opacity: 1,
       strokeOpacity: 1,
       fillOpacity: 1,
     };

--- a/packages/g-svg/src/shape/rect.ts
+++ b/packages/g-svg/src/shape/rect.ts
@@ -28,7 +28,6 @@ class Rect extends ShapeBase {
     const attrs = this.attr();
     const el = this.get('el');
     el.setAttribute('d', this._assembleRect(attrs));
-    // console.log(el.parentNode);
   }
 
   _assembleRect(attrs) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #358.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- `父元素`、`祖先元素`、`canvas` 的 opacity 属性都会与子元素的 opacity 进行叠加(相乘处理)。
- `Element` 的默认 opacity 均为 1，包括 Canvas、Group 和 Shape。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix that `opacity` attr should be composite with parent. #358          |
| 🇨🇳 Chinese | 🐞[g-canvas] 修复父子元素的 `opacity` 绘图属性无法叠加的问题。#358          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
