### PR TITLE
fix(mouseleave): fixed bug of mouseleave

### DIFF
--- a/packages/g-canvas/tests/bugs/issue-drag-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-drag-spec.js
@@ -2,8 +2,7 @@ const expect = require('chai').expect;
 import Canvas from '../../src/canvas';
 // import { transform } from '@antv/matrix-util';
 // import { getColor } from '../get-color';
-
-export function simulateMouseEvent(dom, type, cfg) {
+function simulateMouseEvent(dom, type, cfg) {
   const event = new MouseEvent(type, cfg);
   dom.dispatchEvent(event);
 }

--- a/packages/g-canvas/tests/bugs/issue-mouseleave-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-mouseleave-spec.js
@@ -1,0 +1,72 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.style.border = '1px solid red';
+
+function simulateMouseEvent(dom, type, cfg) {
+  const event = new MouseEvent(type, cfg);
+  dom.dispatchEvent(event);
+}
+
+describe('mouseleave', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 100,
+    height: 100,
+  });
+
+  const g = canvas.addGroup({
+    name: 'group',
+  });
+  g.addShape({
+    type: 'rect',
+    name: 'test',
+    attrs: {
+      x: 50,
+      y: 90,
+      width: 20,
+      height: 10,
+      fill: 'red',
+    },
+  });
+  const shape = canvas.addShape({
+    type: 'rect',
+    attrs: {
+      x: 50,
+      y: 10,
+      width: 20,
+      height: 50,
+      fill: 'red',
+    },
+  });
+  const el = canvas.get('el');
+  it('mouseleave test', () => {
+    canvas.on('group:mouseenter', (ev) => {
+      shape.attr('fill', 'blue');
+      ev.shape.attr('fill', 'blue');
+    });
+    canvas.on('group:mouseleave', (ev) => {
+      ev.shape.attr('fill', 'red');
+      shape.attr('fill', 'red');
+    });
+    const point = canvas.getClientByPoint(50, 100);
+    simulateMouseEvent(el, 'mouseenter', {
+      clientX: point.x,
+      clientY: point.y,
+    });
+    expect(shape.attr('fill')).eql('blue');
+
+    simulateMouseEvent(el, 'mouseout', {
+      clientX: point.x,
+      clientY: point.y + 1,
+    });
+
+    simulateMouseEvent(el, 'mouseleave', {
+      clientX: point.x,
+      clientY: point.y + 1,
+    });
+    expect(shape.attr('fill')).eql('red');
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

* 通过加个临时变量，如果是离开画布的事件，不重新设置 currentShape，下次 进入画布时会重置 currentShape，实现不算优雅，但是能够解决问题。其他的解决方案有：
  + 仅实现 mouseout 或者 mouseleave，在这个事件中触发两个事件
  + getShape 不通过当前 x,y 来判定，而通过离开画布边缘的位置进行判定，这个方案存在潜在的问题
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
