### PR TITLE
fix(g-base): should emit drag event for canvas only when draggable is true

### DIFF
--- a/packages/g-base/tests/unit/event-spec.js
+++ b/packages/g-base/tests/unit/event-spec.js
@@ -662,6 +662,8 @@ describe('test graphic events', () => {
     let drag = false;
     let end = false;
     let shapeStart = false;
+    shape1.set('draggable', true);
+
     canvas.on('dragstart', () => {
       start = true;
     });
@@ -694,7 +696,7 @@ describe('test graphic events', () => {
       clientY,
     });
     expect(start).eql(true);
-    expect(shapeStart).eql(false);
+    expect(shapeStart).eql(true);
     simulateMouseEvent(element, 'mousemove', {
       clientX: clientX + 11,
       clientY,

--- a/packages/g-canvas/tests/bugs/issue-380-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-380-spec.js
@@ -1,0 +1,124 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { simulateMouseEvent, getClientPoint } from '../util';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+dom.style.border = '1px solid black';
+
+describe('#380', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+  });
+
+  const el = canvas.get('el');
+
+  function triggerEvent() {
+    const { clientX, clientY } = getClientPoint(canvas, 200, 200);
+    simulateMouseEvent(el, 'mousedown', {
+      clientX,
+      clientY,
+    });
+
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 10,
+      clientY,
+    });
+
+    // 要模拟 drag 事件，需要触发 mousemove 事件两次以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 20,
+      clientY,
+    });
+
+    simulateMouseEvent(el, 'mouseup', {
+      clientX: clientX + 30,
+      clientY,
+    });
+  }
+
+  it('should emit drag event for canvas only when draggable is true', () => {
+    canvas.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 50,
+        fill: 'red',
+      },
+    });
+
+    let dragstartCalled = false;
+    let dragCalled = false;
+    let dragendCalled = false;
+    let mousedownCalled = false;
+    let mousemoveCalled = false;
+    let mouseupCalled = false;
+    let clickCalled = false;
+
+    canvas.on('dragstart', () => {
+      dragstartCalled = true;
+    });
+
+    canvas.on('drag', () => {
+      dragCalled = true;
+    });
+
+    canvas.on('dragend', () => {
+      dragendCalled = true;
+    });
+
+    canvas.on('mousedown', () => {
+      mousedownCalled = true;
+    });
+
+    canvas.on('mousemove', () => {
+      mousemoveCalled = true;
+    });
+
+    canvas.on('mouseup', () => {
+      mouseupCalled = true;
+    });
+
+    canvas.on('click', () => {
+      clickCalled = true;
+    });
+
+    // 触发模拟事件
+    triggerEvent();
+
+    expect(dragstartCalled).eqls(false);
+    expect(dragCalled).eqls(false);
+    expect(dragendCalled).eqls(false);
+    expect(mousedownCalled).eqls(true);
+    expect(mousemoveCalled).eqls(true);
+    expect(mouseupCalled).eqls(true);
+    expect(clickCalled).eqls(true);
+
+    // 重置标记
+    dragstartCalled = false;
+    dragCalled = false;
+    dragendCalled = false;
+    mousedownCalled = false;
+    mousemoveCalled = false;
+    mouseupCalled = false;
+    clickCalled = false;
+
+    // 设置 canvas 可拖拽
+    canvas.set('draggable', true);
+    // 触发模拟事件
+    triggerEvent();
+
+    expect(dragstartCalled).eqls(true);
+    expect(dragCalled).eqls(true);
+    expect(dragendCalled).eqls(true);
+    expect(mousedownCalled).eqls(true);
+    // mousemove 是否触发取决于拖拽的速度和距离。由于事件是模拟的，不太好把握拖拽的速度和距离，因此这里不会触发 mousemove 事件
+    // 实际上如果拖拽较快的话，mousemove 会在 dragstart 事件之前触发
+    expect(mousemoveCalled).eqls(false);
+    expect(mouseupCalled).eqls(false);
+    expect(clickCalled).eqls(false);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #380.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

-  `draggable: false` 时，对画布进行拖拽操作，事件响应顺序为: `mousedown -> mousemove -> mouseup -> click`;
- `draggable: true` 时，对画布进行拖拽操作，事件响应顺序为: `mousedown -> mousemove(是否触发取决于拖拽的速度和距离) -> dragstart -> drag -> dragend`;

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix that canvas could emit drag event when `draggable` is false. #380        |
| 🇨🇳 Chinese | 🐞 [g-base] 修复当 `draggable` 为 `false` 时，canvas 能够触发 `drag` 事件的问题。#380          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
