### PR TITLE
fix(g-base): compatible with previous onFrame usage and function cannot be interpolated

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -465,6 +465,9 @@ abstract class Element extends Base implements IElement {
     if (isFunction(toAttrs)) {
       onFrame = toAttrs as OnFrame;
       toAttrs = {};
+    } else if (isObject(toAttrs) && (toAttrs as any).onFrame) {
+      // 兼容 3.0 中的写法，onFrame 可在 toAttrs 中设置
+      onFrame = (toAttrs as any).onFrame as OnFrame;
     }
     // 第二个参数，既可以是执行时间 duration，也可以是动画参数 animateCfg
     if (isObject(duration)) {

--- a/packages/g-base/src/animate/timeline.ts
+++ b/packages/g-base/src/animate/timeline.ts
@@ -1,4 +1,4 @@
-import { isEqual, isNumber } from '@antv/util';
+import { isEqual, isNumber, isFunction } from '@antv/util';
 import * as d3Timer from 'd3-timer';
 import * as d3Ease from 'd3-ease';
 import { interpolate, interpolateArray } from 'd3-interpolate'; // 目前整体动画只需要数值和数组的差值计算
@@ -68,7 +68,8 @@ function _update(shape: IElement, animation: Animation, ratio: number) {
         cProps[k] = currentMatrix;
       } else if (isColorProp(k) && isGradientColor(toAttrs[k])) {
         cProps[k] = toAttrs[k];
-      } else {
+      } else if (!isFunction(toAttrs[k])) {
+        // 非函数类型的值才能做插值
         interf = interpolate(fromAttrs[k], toAttrs[k]);
         cProps[k] = interf(ratio);
       }

--- a/packages/g-base/tests/unit/animate-spec.js
+++ b/packages/g-base/tests/unit/animate-spec.js
@@ -61,6 +61,46 @@ describe('animate', () => {
     }, 700);
   });
 
+  // 兼容 3.0 中的写法，onFrame 可在 toAttrs 中设置
+  it('animate(toAttrs, duration, easing, callback, delay) and toAttrs has onFrame property', (done) => {
+    const shape = new Shape({
+      attrs: {
+        x: 50,
+        y: 50,
+      },
+    });
+    canvas.add(shape);
+    let flag = false;
+    shape.animate(
+      {
+        onFrame: (ratio) => {
+          return {
+            x: 50 + ratio * (100 - 50),
+            y: 50 + ratio * (100 - 50),
+          };
+        },
+      },
+      500,
+      'easeLinear',
+      () => {
+        flag = true;
+      },
+      100
+    );
+    expect(shape.attr('x')).eqls(50);
+    expect(shape.attr('y')).eqls(50);
+    expect(flag).eqls(false);
+    setTimeout(() => {
+      expect(flag).eqls(false);
+    }, 550);
+    setTimeout(() => {
+      expect(shape.attr('x')).eqls(100);
+      expect(shape.attr('y')).eqls(100);
+      expect(flag).eqls(true);
+      done();
+    }, 1200);
+  });
+
   it('animate(onFrame, duration, easing, callback, delay)', (done) => {
     const shape = new Shape({
       attrs: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #332.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix `animate` method of Element not compatible with `onFrame` usage in 3.0 + Fix the error when value of function type is interpolated. #332          |
| 🇨🇳 Chinese | 🐞 [g-base] 兼容 3.0 中 `onFrame` 的用法 + 修复函数类型的绘图属性值进行动画插值时页面报错的问题。#332   |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
