### PR TITLE
fix(g-svg): opacity attr for Rect should work

### DIFF
--- a/packages/g-svg/src/shape/circle.ts
+++ b/packages/g-svg/src/shape/circle.ts
@@ -3,7 +3,7 @@
  * @author dengfuping_develop@163.com
  */
 
-import { each, isArray } from '@antv/util';
+import { each } from '@antv/util';
 import { SVG_ATTR_MAP } from '../constant';
 import ShapeBase from './base';
 

--- a/packages/g-svg/src/shape/rect.ts
+++ b/packages/g-svg/src/shape/rect.ts
@@ -3,8 +3,9 @@
  * @author dengfuping_develop@163.com
  */
 
-import { isArray } from '@antv/util';
+import { each, isArray } from '@antv/util';
 import ShapeBase from './base';
+import { SVG_ATTR_MAP } from '../constant';
 import { parseRadius } from '../util/format';
 
 class Rect extends ShapeBase {
@@ -27,7 +28,18 @@ class Rect extends ShapeBase {
   createPath(context, targetAttrs) {
     const attrs = this.attr();
     const el = this.get('el');
-    el.setAttribute('d', this._assembleRect(attrs));
+    // 加上状态量，用来标记 path 是否已组装
+    let completed = false;
+    // 和组装 path 相关的绘图属性
+    const pathRelatedAttrs = ['x', 'y', 'width', 'height', 'radius'];
+    each(targetAttrs || attrs, (value, attr) => {
+      if (pathRelatedAttrs.indexOf(attr) !== -1 && !completed) {
+        el.setAttribute('d', this._assembleRect(attrs));
+        completed = true;
+      } else if (pathRelatedAttrs.indexOf(attr) === -1 && SVG_ATTR_MAP[attr]) {
+        el.setAttribute(SVG_ATTR_MAP[attr], value);
+      }
+    });
   }
 
   _assembleRect(attrs) {

--- a/packages/g-svg/tests/bugs/issue-388-spec.js
+++ b/packages/g-svg/tests/bugs/issue-388-spec.js
@@ -88,4 +88,20 @@ describe('#388', () => {
       done();
     }, 120);
   });
+
+  it('opacity attr for Rect should work', () => {
+    const group = canvas.addGroup();
+    const rect = group.addShape('rect', {
+      attrs: {
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 150,
+        fill: 'rgba(220, 0, 150, .5)',
+        opacity: 0.3,
+      },
+    });
+    const el = rect.get('el');
+    expect(el.getAttribute('opacity')).eqls('0.3');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: 388;

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix `opacity` attr not work for Rect. #388           |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复 Rect 的 `opacity` 绘图属性不生效的问题。#388          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
