### PR TITLE
fix(g-svg): null for fill and stroke attr should work

### DIFF
--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -1,5 +1,6 @@
 import { AbstractShape } from '@antv/g-base';
 import { ShapeAttrs, ChangeType, BBox } from '@antv/g-base/lib/types';
+import { isUndefined } from '@antv/util';
 import { IShape } from '../interfaces';
 import Defs from '../defs';
 import { setShadow, setTransform, setClip } from '../util/svg';
@@ -136,14 +137,19 @@ class ShapeBase extends AbstractShape implements IShape {
 
   // stroke and fill
   strokeAndFill(context, targetAttrs?) {
-    const attrs = this.attr();
-    const { fill, fillStyle, stroke, strokeStyle, fillOpacity, strokeOpacity, lineWidth } = targetAttrs || attrs;
+    const attrs = targetAttrs || this.attr();
+    const { fill, fillStyle, stroke, strokeStyle, fillOpacity, strokeOpacity, lineWidth } = attrs;
     const el = this.get('el');
 
     if (this.canFill) {
-      // compatible with fillStyle
-      if (fill || fillStyle || !targetAttrs) {
+      // 初次渲染和更新渲染的逻辑有所不同: 初次渲染值为空时，需要设置为 none，否则就会是黑色，而更新渲染则不需要
+      if (!targetAttrs) {
         this._setColor(context, 'fill', fill || fillStyle);
+      } else if ('fill' in attrs) {
+        this._setColor(context, 'fill', fill);
+      } else if ('fillStyle' in attrs) {
+        // compatible with fillStyle
+        this._setColor(context, 'fill', fillStyle);
       }
       if (fillOpacity) {
         el.setAttribute(SVG_ATTR_MAP['fillOpacity'], fillOpacity);
@@ -151,9 +157,13 @@ class ShapeBase extends AbstractShape implements IShape {
     }
 
     if (this.canStroke && lineWidth > 0) {
-      // compatible with strokeStyle
-      if (stroke || strokeStyle || !targetAttrs) {
+      if (!targetAttrs) {
         this._setColor(context, 'stroke', stroke || strokeStyle);
+      } else if ('stroke' in attrs) {
+        this._setColor(context, 'stroke', stroke);
+      } else if ('strokeStyle' in attrs) {
+        // compatible with strokeStyle
+        this._setColor(context, 'stroke', strokeStyle);
       }
       if (strokeOpacity) {
         el.setAttribute(SVG_ATTR_MAP['strokeOpacity'], strokeOpacity);

--- a/packages/g-svg/tests/bugs/issue-388-spec.js
+++ b/packages/g-svg/tests/bugs/issue-388-spec.js
@@ -104,4 +104,23 @@ describe('#388', () => {
     const el = rect.get('el');
     expect(el.getAttribute('opacity')).eqls('0.3');
   });
+
+  it('null for fill and stroke attr should work', (done) => {
+    const group = canvas.addGroup();
+    const rect = group.addShape('rect', {
+      attrs: {
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 150,
+        fill: 'red',
+      },
+    });
+    setTimeout(() => {
+      rect.attr('fill', null);
+    }, 200);
+    setTimeout(() => {
+      done();
+    }, 300);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #388;

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix `null` for fill and stroke attr not work. #388         |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复 fill 和 stroke 绘图属性的 `null` 值不生效的问题。#388          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
