### PR TITLE
fix(g-svg): should not create marker defs dom when startArrow or endArrow is false

### DIFF
--- a/packages/g-svg/src/shape/line.ts
+++ b/packages/g-svg/src/shape/line.ts
@@ -3,7 +3,7 @@
  * @author dengfuping_develop@163.com
  */
 import LineUtil from '@antv/g-math/lib/line';
-import { each, isBoolean } from '@antv/util';
+import { each, isObject } from '@antv/util';
 import { SVG_ATTR_MAP } from '../constant';
 import ShapeBase from './base';
 
@@ -30,10 +30,14 @@ class Line extends ShapeBase {
     const el = this.get('el');
     each(targetAttrs || attrs, (value, attr) => {
       if (attr === 'startArrow' || attr === 'endArrow') {
-        const id = isBoolean(value)
-          ? context.getDefaultArrow(attrs, SVG_ATTR_MAP[attr])
-          : context.addArrow(attrs, SVG_ATTR_MAP[attr]);
-        el.setAttribute(SVG_ATTR_MAP[attr], `url(#${id})`);
+        if (value) {
+          const id = isObject(value)
+            ? context.addArrow(attrs, SVG_ATTR_MAP[attr])
+            : context.getDefaultArrow(attrs, SVG_ATTR_MAP[attr]);
+          el.setAttribute(SVG_ATTR_MAP[attr], `url(#${id})`);
+        } else {
+          el.removeAttribute(SVG_ATTR_MAP[attr]);
+        }
       } else if (SVG_ATTR_MAP[attr]) {
         el.setAttribute(SVG_ATTR_MAP[attr], value);
       }

--- a/packages/g-svg/src/shape/path.ts
+++ b/packages/g-svg/src/shape/path.ts
@@ -3,7 +3,7 @@
  * @author dengfuping_develop@163.com
  */
 import { Point } from '@antv/g-base/lib/types';
-import { each, isArray, isBoolean } from '@antv/util';
+import { each, isArray, isObject } from '@antv/util';
 import { SVG_ATTR_MAP } from '../constant';
 import ShapeBase from './base';
 
@@ -28,10 +28,14 @@ class Path extends ShapeBase {
       if (attr === 'path' && isArray(value)) {
         el.setAttribute('d', this._formatPath(value));
       } else if (attr === 'startArrow' || attr === 'endArrow') {
-        const id = isBoolean(value)
-          ? context.getDefaultArrow(attrs, SVG_ATTR_MAP[attr])
-          : context.addArrow(attrs, SVG_ATTR_MAP[attr]);
-        el.setAttribute(SVG_ATTR_MAP[attr], `url(#${id})`);
+        if (value) {
+          const id = isObject(value)
+            ? context.addArrow(attrs, SVG_ATTR_MAP[attr])
+            : context.getDefaultArrow(attrs, SVG_ATTR_MAP[attr]);
+          el.setAttribute(SVG_ATTR_MAP[attr], `url(#${id})`);
+        } else {
+          el.removeAttribute(SVG_ATTR_MAP[attr]);
+        }
       } else if (SVG_ATTR_MAP[attr]) {
         el.setAttribute(SVG_ATTR_MAP[attr], value);
       }

--- a/packages/g-svg/tests/unit/defs/arrow-spec.js
+++ b/packages/g-svg/tests/unit/defs/arrow-spec.js
@@ -1,0 +1,33 @@
+const expect = require('chai').expect;
+import { Canvas } from '../../../src/index';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('Arrow defs', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+  });
+
+  it('should not create marker defs dom when startArrow or endArrow is false', () => {
+    const line = canvas.addShape('line', {
+      attrs: {
+        x1: 20,
+        y1: 20,
+        x2: 50,
+        y2: 50,
+        stroke: 'red',
+        startArrow: false,
+        endArrow: false,
+      },
+    });
+    const el = line.get('el');
+    const markerNodes = document.getElementsByTagName('marker');
+    expect(el.getAttribute('marker-start')).eqls(null);
+    expect(el.getAttribute('marker-end')).eqls(null);
+    expect(markerNodes.length).eqls(0);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- `startArrow` 和 `endArrow` 的值为空时，图形对应的 el 既不设置 `marker-start` 和 `marker-end` 属性，也不生成对应的 `marker defs` 元素。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
