### PR TITLE
fix(svg): should not generate svg elements repeatedly when canvas.draw()

### DIFF
--- a/packages/g-svg/src/canvas.ts
+++ b/packages/g-svg/src/canvas.ts
@@ -1,7 +1,7 @@
 import { AbstractCanvas } from '@antv/g-base';
 import { ChangeType } from '@antv/g-base/lib/types';
 import { IElement } from './interfaces';
-import { drawPathChildren } from './util/draw';
+import { drawChildren } from './util/draw';
 import { setTransform, setClip } from './util/svg';
 import { sortDom } from './util/dom';
 import EventController from '@antv/g-base/lib/event/event-contoller';
@@ -17,46 +17,6 @@ class Canvas extends AbstractCanvas {
       // 设置渲染引擎为 canvas，只读属性
       renderer: 'svg',
     });
-  }
-
-  // 覆盖基类中的 set 方法
-  set(name, value) {
-    // autoDraw 不可修改，始终为 true
-    // TODO: 应该在控制台给出 Warning 提示，引导用户避免这种用法。需要在 @antv/util 中提供通用的 warning 方法，便于在其他 antv 项目中使用
-    if (name === 'autoDraw') {
-      this.cfg[name] = true;
-    } else {
-      super.set(name, value);
-    }
-  }
-
-  /**
-   * 一些方法调用会引起画布变化
-   * @param {ChangeType} changeType 改变的类型
-   */
-  onCanvasChange(changeType: ChangeType) {
-    const context = this.get('context');
-    const el = this.get('el');
-    if (changeType === 'sort') {
-      const children = this.get('children');
-      if (children && children.length) {
-        sortDom(this, (a: IElement, b: IElement) => {
-          return children.indexOf(a) - children.indexOf(b) ? 1 : 0;
-        });
-      }
-    } else if (changeType === 'clear') {
-      // el is null for canvas
-      if (el) {
-        el.innerHTML = '';
-      }
-    } else if (changeType === 'matrix') {
-      setTransform(this);
-    } else if (changeType === 'clip') {
-      setClip(this, context);
-    } else if (changeType === 'changeSize') {
-      el.setAttribute('width', `${this.get('width')}`);
-      el.setAttribute('height', `${this.get('height')}`);
-    }
   }
 
   getShapeBase() {
@@ -78,17 +38,48 @@ class Canvas extends AbstractCanvas {
     return element;
   }
 
+  /**
+   * 一些方法调用会引起画布变化
+   * @param {ChangeType} changeType 改变的类型
+   */
+  onCanvasChange(changeType: ChangeType) {
+    const context = this.get('context');
+    const el = this.get('el');
+    if (changeType === 'sort') {
+      const children = this.get('children');
+      if (children && children.length) {
+        sortDom(this, (a: IElement, b: IElement) => {
+          return children.indexOf(a) - children.indexOf(b) ? 1 : 0;
+        });
+      }
+    } else if (changeType === 'clear') {
+      // el maybe null for canvas
+      if (el) {
+        // 清空 SVG 元素
+        el.innerHTML = '';
+        const defsEl = context.el;
+        // 清空 defs 元素
+        defsEl.innerHTML = '';
+        // 将清空后的 defs 元素挂载到 el 下
+        el.appendChild(defsEl);
+      }
+    } else if (changeType === 'matrix') {
+      setTransform(this);
+    } else if (changeType === 'clip') {
+      setClip(this, context);
+    } else if (changeType === 'changeSize') {
+      el.setAttribute('width', `${this.get('width')}`);
+      el.setAttribute('height', `${this.get('height')}`);
+    }
+  }
+
   // 复写基类的 draw 方法
   draw() {
     const context = this.get('context');
-    setClip(this, context);
-    this.drawPath(context);
-  }
-
-  drawPath(context: Defs) {
     const children = this.getChildren() as IElement[];
+    setClip(this, context);
     if (children.length) {
-      drawPathChildren(context, children);
+      drawChildren(context, children);
     }
   }
 

--- a/packages/g-svg/src/defs/index.ts
+++ b/packages/g-svg/src/defs/index.ts
@@ -66,6 +66,7 @@ class Defs {
     const arrow = new Arrow(attrs, name);
     this.defaultArrow[stroke] = arrow;
     this.el.appendChild(arrow.el);
+    this.add(arrow);
     return arrow.id;
   }
 
@@ -79,6 +80,7 @@ class Defs {
   addArrow(attrs, name) {
     const arrow = new Arrow(attrs, name);
     this.el.appendChild(arrow.el);
+    this.add(arrow);
     return arrow.id;
   }
 

--- a/packages/g-svg/src/group.ts
+++ b/packages/g-svg/src/group.ts
@@ -4,7 +4,7 @@ import { each } from '@antv/util';
 import { IElement, IGroup } from './interfaces';
 import * as Shape from './shape';
 import Defs from './defs';
-import { drawChildren, drawPathChildren, refreshElement } from './util/draw';
+import { drawChildren, refreshElement } from './util/draw';
 import { setClip, setTransform } from './util/svg';
 import { SVG_ATTR_MAP } from './constant';
 
@@ -39,7 +39,7 @@ class Group extends AbstractGroup {
     // 只有挂载到画布下，才对元素进行实际渲染
     if (canvas) {
       const context = canvas.get('context');
-      this.updatePath(context, targetAttrs);
+      this.drawPath(context, targetAttrs);
     }
   }
 
@@ -60,20 +60,30 @@ class Group extends AbstractGroup {
   }
 
   draw(context: Defs) {
-    setClip(this, context);
-    this.drawPath(context);
-  }
-
-  drawPath(context: Defs) {
     const children = this.getChildren() as IElement[];
-    this.createDom();
-    this.updatePath(context);
-    if (children.length) {
-      drawPathChildren(context, children);
+    const el = this.get('el');
+    if (this.get('destroyed')) {
+      if (el) {
+        el.parentNode.removeChild(el);
+      }
+    } else {
+      if (!el) {
+        this.createDom();
+      }
+      setClip(this, context);
+      this.drawPath(context);
+      if (children.length) {
+        drawChildren(context, children);
+      }
     }
   }
 
-  updatePath(context: Defs, targetAttrs?) {
+  /**
+   * 绘制分组的路径
+   * @param {Defs} context 上下文
+   * @param {ShapeAttrs} targetAttrs 渲染的目标属性
+   */
+  drawPath(context: Defs, targetAttrs?) {
     const attrs = this.attr();
     const el = this.get('el');
     each(targetAttrs || attrs, (value, attr) => {

--- a/packages/g-svg/src/interfaces.ts
+++ b/packages/g-svg/src/interfaces.ts
@@ -10,12 +10,6 @@ export interface IElement extends IBaseElement {
    * @param {Defs} context 上下文
    */
   draw(context: Defs);
-
-  /**
-   * 绘制图形元素
-   * @param {Defs} context 上下文
-   */
-  drawPath(context);
 }
 
 export interface IGroup extends IBaseGroup {

--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -34,7 +34,7 @@ class ShapeBase extends AbstractShape implements IShape {
     // 只有挂载到画布下，才对元素进行实际渲染
     if (canvas) {
       const context = canvas.get('context');
-      this.updatePath(context, targetAttrs);
+      this.drawPath(context, targetAttrs);
     }
   }
 
@@ -99,28 +99,29 @@ class ShapeBase extends AbstractShape implements IShape {
   }
 
   draw(context) {
-    setClip(this, context);
-    this.drawPath(context);
+    const el = this.get('el');
+    if (this.get('destroyed')) {
+      if (el) {
+        el.parentNode.removeChild(el);
+      }
+    } else {
+      if (!el) {
+        createDom(this);
+      }
+      setClip(this, context);
+      this.createPath(context);
+      this.shadow(context);
+      this.strokeAndFill(context);
+      this.transform();
+    }
   }
 
   /**
    * 绘制图形的路径
    * @param {Defs} context 上下文
-   */
-  drawPath(context: Defs) {
-    createDom(this);
-    this.createPath(context);
-    this.shadow(context);
-    this.strokeAndFill(context);
-    this.transform();
-  }
-
-  /**
-   * 更新图形的路径
-   * @param {Defs} context 上下文
    * @param {ShapeAttrs} targetAttrs 渲染的目标属性
    */
-  updatePath(context: Defs, targetAttrs: ShapeAttrs) {
+  drawPath(context: Defs, targetAttrs: ShapeAttrs) {
     this.createPath(context, targetAttrs);
     this.shadow(context, targetAttrs);
     this.strokeAndFill(context, targetAttrs);

--- a/packages/g-svg/src/util/draw.ts
+++ b/packages/g-svg/src/util/draw.ts
@@ -10,13 +10,6 @@ export function drawChildren(context: Defs, children: IElement[]) {
   });
 }
 
-export function drawPathChildren(context: Defs, children: IElement[]) {
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i];
-    child.drawPath(context);
-  }
-}
-
 /**
  * 更新元素，包括 group 和 shape
  * @param {IElement} element       SVG 元素
@@ -26,8 +19,8 @@ export function refreshElement(element: IElement, changeType: ChangeType) {
   // 对于还没有挂载到画布下的元素，canvas 可能为空
   const canvas = element.get('canvas');
   // 只有挂载到画布下，才对元素进行实际渲染
-  if (canvas) {
-    const context = canvas && canvas.get('context');
+  if (canvas && canvas.get('autoDraw')) {
+    const context = canvas.get('context');
     const parent = element.getParent();
     const parentChildren = parent ? parent.getChildren() : [canvas];
     const el = element.get('el');
@@ -57,7 +50,7 @@ export function refreshElement(element: IElement, changeType: ChangeType) {
         });
       }
     } else if (changeType === 'clear') {
-      // el is null for group
+      // el maybe null for group
       if (el) {
         el.innerHTML = '';
       }
@@ -68,7 +61,7 @@ export function refreshElement(element: IElement, changeType: ChangeType) {
     } else if (changeType === 'attr') {
       // 已在 afterAttrsChange 进行了处理，此处 do nothing
     } else if (changeType === 'add') {
-      element.drawPath(context);
+      element.draw(context);
     }
   }
 }

--- a/packages/g-svg/tests/bugs/issue-191-spec.js
+++ b/packages/g-svg/tests/bugs/issue-191-spec.js
@@ -17,10 +17,10 @@ describe('#191', () => {
     });
   });
 
-  it('autoDraw should be true and immutable', () => {
+  it('autoDraw should be mutable', () => {
     expect(canvas.get('autoDraw')).eqls(true);
     canvas.set('autoDraw', false);
-    expect(canvas.get('autoDraw')).eqls(true);
+    expect(canvas.get('autoDraw')).eqls(false);
   });
 
   it('avoid redundant rendering when animating', (done) => {

--- a/packages/g-svg/tests/bugs/issue-388-spec.js
+++ b/packages/g-svg/tests/bugs/issue-388-spec.js
@@ -123,4 +123,30 @@ describe('#388', () => {
       done();
     }, 300);
   });
+
+  it('should not generate svg elements repeatedly when canvas.draw()', () => {
+    // 将之前测试用例生成的子元素清空
+    canvas.clear();
+    const group = canvas.addGroup();
+    const circle = group.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 50,
+        fill: 'red',
+      },
+    });
+    circle.setClip({
+      type: 'rect',
+      attrs: {
+        x: 75,
+        y: 75,
+        width: 50,
+        height: 50,
+      },
+    });
+    canvas.draw();
+    // <defs> 元素 + <g> 元素
+    expect(canvas.get('el').childNodes.length).eqls(2);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #388.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 修复当收到调用 canvas.draw() 方法时，SVG 元素重复生成的问题
- 修复 `autoDraw` 无法修改的问题。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix svg elements generated repeatedly when canvas.draw(). #388         |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复当收到调用 canvas.draw() 方法时，SVG 元素重复生成的问题。#388          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
