### PR TITLE
fix(g-svg): should work when autoDraw is false

### DIFF
--- a/packages/g-svg/src/group.ts
+++ b/packages/g-svg/src/group.ts
@@ -37,9 +37,9 @@ class Group extends AbstractGroup {
     super.afterAttrsChange(targetAttrs);
     const canvas = this.get('canvas');
     // 只有挂载到画布下，才对元素进行实际渲染
-    if (canvas) {
+    if (canvas && canvas.get('autoDraw')) {
       const context = canvas.get('context');
-      this.drawPath(context, targetAttrs);
+      this.createPath(context, targetAttrs);
     }
   }
 
@@ -71,7 +71,7 @@ class Group extends AbstractGroup {
         this.createDom();
       }
       setClip(this, context);
-      this.drawPath(context);
+      this.createPath(context);
       if (children.length) {
         drawChildren(context, children);
       }
@@ -83,7 +83,7 @@ class Group extends AbstractGroup {
    * @param {Defs} context 上下文
    * @param {ShapeAttrs} targetAttrs 渲染的目标属性
    */
-  drawPath(context: Defs, targetAttrs?) {
+  createPath(context: Defs, targetAttrs?) {
     const attrs = this.attr();
     const el = this.get('el');
     each(targetAttrs || attrs, (value, attr) => {

--- a/packages/g-svg/src/interfaces.ts
+++ b/packages/g-svg/src/interfaces.ts
@@ -9,7 +9,7 @@ export interface IElement extends IBaseElement {
    * 裁剪和绘制图形元素
    * @param {Defs} context 上下文
    */
-  draw(context: Defs);
+  draw(context: Defs, targetAttrs?);
 }
 
 export interface IGroup extends IBaseGroup {

--- a/packages/g-svg/src/shape/base.ts
+++ b/packages/g-svg/src/shape/base.ts
@@ -32,9 +32,9 @@ class ShapeBase extends AbstractShape implements IShape {
     super.afterAttrsChange(targetAttrs);
     const canvas = this.get('canvas');
     // 只有挂载到画布下，才对元素进行实际渲染
-    if (canvas) {
+    if (canvas && canvas.get('autoDraw')) {
       const context = canvas.get('context');
-      this.drawPath(context, targetAttrs);
+      this.draw(context, targetAttrs);
     }
   }
 
@@ -98,7 +98,7 @@ class ShapeBase extends AbstractShape implements IShape {
     return (stroke || strokeStyle) && this.canStroke;
   }
 
-  draw(context) {
+  draw(context, targetAttrs) {
     const el = this.get('el');
     if (this.get('destroyed')) {
       if (el) {
@@ -109,23 +109,11 @@ class ShapeBase extends AbstractShape implements IShape {
         createDom(this);
       }
       setClip(this, context);
-      this.createPath(context);
-      this.shadow(context);
-      this.strokeAndFill(context);
-      this.transform();
+      this.createPath(context, targetAttrs);
+      this.shadow(context, targetAttrs);
+      this.strokeAndFill(context, targetAttrs);
+      this.transform(targetAttrs);
     }
-  }
-
-  /**
-   * 绘制图形的路径
-   * @param {Defs} context 上下文
-   * @param {ShapeAttrs} targetAttrs 渲染的目标属性
-   */
-  drawPath(context: Defs, targetAttrs: ShapeAttrs) {
-    this.createPath(context, targetAttrs);
-    this.shadow(context, targetAttrs);
-    this.strokeAndFill(context, targetAttrs);
-    this.transform(targetAttrs);
   }
 
   /**

--- a/packages/g-svg/tests/bugs/issue-388-spec.js
+++ b/packages/g-svg/tests/bugs/issue-388-spec.js
@@ -149,4 +149,22 @@ describe('#388', () => {
     // <defs> 元素 + <g> 元素
     expect(canvas.get('el').childNodes.length).eqls(2);
   });
+
+  it('should work when autoDraw is false', () => {
+    canvas.set('autoDraw', false);
+    const group = canvas.addGroup();
+    const circle = group.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 50,
+        fill: 'red',
+      },
+    });
+    circle.translate(20, 20);
+    canvas.draw();
+    expect(circle.get('el').getAttribute('transform')).eqls('matrix(1,0,0,1,20,20)');
+    // 重置 autoDraw，避免影响其他的测试用例
+    canvas.set('autoDraw', true);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #388;
- Ref: https://riddle.alibaba-inc.com/riddles/95caf617

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix not work when autoDraw is false. #388        |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复自动渲染模式无法正常运行的问题。#388          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
