### PR TITLE
fix(g-svg): default arrow rendering should be same with Canvas

### DIFF
--- a/packages/g-svg/src/defs/arrow.ts
+++ b/packages/g-svg/src/defs/arrow.ts
@@ -19,8 +19,8 @@ class Arrow {
     const id = uniqueId('marker_');
     el.setAttribute('id', id);
     const shape = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    shape.setAttribute('stroke', 'none');
-    shape.setAttribute('fill', attrs.stroke || '#000');
+    shape.setAttribute('stroke', attrs.stroke || 'none');
+    shape.setAttribute('fill', attrs.fill || 'none');
     el.appendChild(shape);
     el.setAttribute('overflow', 'visible');
     el.setAttribute('orient', 'auto-start-reverse');
@@ -44,9 +44,10 @@ class Arrow {
 
   _setDefaultPath(type, el) {
     const parent = this.el;
-    el.setAttribute('d', 'M0,0 L6,3 L0,6 L3,3Z');
-    parent.setAttribute('refX', `${3}`);
-    parent.setAttribute('refY', `${3}`);
+    // 默认箭头的边长为 10，夹角为 60 度
+    el.setAttribute('d', `M0,0 L${10 * Math.cos(Math.PI / 6)},5 L0,10`);
+    parent.setAttribute('refX', `${10 * Math.cos(Math.PI / 6)}`);
+    parent.setAttribute('refY', `${5}`);
   }
 
   _setMarker(r, el) {

--- a/packages/g-svg/tests/unit/defs/arrow-spec.js
+++ b/packages/g-svg/tests/unit/defs/arrow-spec.js
@@ -12,6 +12,31 @@ describe('Arrow defs', () => {
     height: 400,
   });
 
+  it.only('default arrow rendering should be same with Canvas', () => {
+    const line = canvas.addShape('line', {
+      attrs: {
+        x1: 50,
+        y1: 50,
+        x2: 100,
+        y2: 100,
+        stroke: 'red',
+        startArrow: true,
+      },
+    });
+    const el = line.get('el');
+    // 格式为: url(#marker_1)
+    const markerStart = el.getAttribute('marker-start');
+    let markerId = markerStart.split('#')[1];
+    markerId = markerId.slice(0, markerId.length - 1);
+    // marker 节点
+    const markerNode = document.getElementById(markerId);
+    expect(markerNode.getAttribute('refX')).eqls(`${10 * Math.cos(Math.PI / 6)}`);
+    expect(markerNode.getAttribute('refY')).eqls(`${5}`);
+    // marker 下对应的箭头 path 节点
+    const pathNode = markerNode.childNodes[0];
+    expect(pathNode.getAttribute('d')).eqls(`M0,0 L${10 * Math.cos(Math.PI / 6)},5 L0,10`);
+  });
+
   it('should not create marker defs dom when startArrow or endArrow is false', () => {
     const line = canvas.addShape('line', {
       attrs: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #388;

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix default arrow rendering not same with Canvas version. #388          |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复默认的箭头渲染样式与 Canvas 版本不一致的问题。#388          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
