### PR TITLE
fix(g-canvas): matrix of element should affect its clip

### DIFF
--- a/packages/g-canvas/src/group.ts
+++ b/packages/g-canvas/src/group.ts
@@ -43,9 +43,10 @@ class Group extends AbstractGroup {
     const children = this.getChildren() as IElement[];
     if (children.length) {
       context.save();
-      this._applyClip(context, this.getClip() as ShapeBase);
       // group 上的矩阵和属性也会应用到上下文上
+      // 先将 attrs 应用到上下文中，再设置 clip。因为 clip 应该被当前元素的 matrix 所影响
       applyAttrsToContext(context, this);
+      this._applyClip(context, this.getClip() as ShapeBase);
       drawChildren(context, children, region);
       context.restore();
     }

--- a/packages/g-canvas/src/shape/base.ts
+++ b/packages/g-canvas/src/shape/base.ts
@@ -94,8 +94,9 @@ class ShapeBase extends AbstractShape {
       }
     }
     context.save();
-    this._applyClip(context, this.getClip() as ShapeBase);
+    // 先将 attrs 应用到上下文中，再设置 clip。因为 clip 应该被当前元素的 matrix 所影响
     applyAttrsToContext(context, this);
+    this._applyClip(context, this.getClip() as ShapeBase);
     this.drawPath(context);
     context.restore();
     this._afterDraw();

--- a/packages/g-canvas/tests/bugs/issue-382-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-382-spec.js
@@ -1,0 +1,73 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { simulateMouseEvent, getClientPoint } from '../util';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#382', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 500,
+    height: 500,
+  });
+
+  const el = canvas.get('el');
+
+  it('matrix of element should affect its clip', () => {
+    const group = canvas.addGroup();
+    const shape = group.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 50,
+        fill: 'red',
+      },
+    });
+    // X 方向移动 100
+    shape.translate(100, 0);
+    shape.setClip({
+      type: 'rect',
+      attrs: {
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100,
+      },
+    });
+    let clickCalled = false;
+    shape.on('click', () => {
+      clickCalled = true;
+    });
+
+    // 加上以下两个事件监听，主要是为了在 interactive 测试模式下，能更直观的感受拾取是否符合预期
+    shape.on('mouseenter', () => {
+      shape.attr('fill', 'blue');
+    });
+
+    shape.on('mouseleave', () => {
+      shape.attr('fill', 'red');
+    });
+
+    const { clientX, clientY } = getClientPoint(canvas, 200, 100);
+    simulateMouseEvent(el, 'mousedown', {
+      clientX: clientX - 10,
+      clientY: clientY + 10,
+    });
+    simulateMouseEvent(el, 'mouseup', {
+      clientX: clientX - 10,
+      clientY: clientY + 10,
+    });
+    expect(clickCalled).eqls(false);
+    simulateMouseEvent(el, 'mousedown', {
+      clientX: clientX + 10,
+      clientY: clientY + 10,
+    });
+    simulateMouseEvent(el, 'mouseup', {
+      clientX: clientX + 10,
+      clientY: clientY + 10,
+    });
+    expect(clickCalled).eqls(true);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #382;

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 对于 `group -> shape -> clip` 的结构，原先只有 group 上的 matrix 才会影响 clip 的拾取，而 shape 上的 matrix 则不会影响。因此会出现 #382 中，如果元素同时设置了 matrix 和 clip，会出现拾取不正确的问题。
- [ ] TODO: SVG 版本之后也要同步实现这一机制

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix incorrect hit when element has `matrix` and `clip` both. #382         |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复元素同时设置了 `matrix` 和 `clip` 时拾取不正确的问题。#382          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
