### PR TITLE
fix(g-canvas): should render when localRefresh change from false to true

### DIFF
--- a/packages/g-canvas/src/canvas.ts
+++ b/packages/g-canvas/src/canvas.ts
@@ -156,6 +156,8 @@ class Canvas extends AbstractCanvas {
     context.clearRect(0, 0, element.width, element.height);
     applyAttrsToContext(context, this);
     drawChildren(context, children);
+    // 对于 https://github.com/antvis/g/issues/422 的场景，全局渲染的模式下也会记录更新的元素队列，因此全局渲染完后也需要置空
+    this.set('refreshElements', []);
   }
   // 绘制局部
   _drawRegion() {

--- a/packages/g-canvas/src/util/draw.ts
+++ b/packages/g-canvas/src/util/draw.ts
@@ -153,11 +153,14 @@ export function refreshElement(element, changeType) {
       // 这是一段 hack 的代码
       element._cacheCanvasBBox = element.get('cacheCanvasBBox');
     }
+    // 防止反复刷新
     if (!element.get('hasChanged')) {
-      // 防止反复刷新
-      if (canvas.get('localRefresh')) {
-        canvas.refreshElement(element, changeType, canvas);
-      }
+      // 本来只有局部渲染模式下，才需要记录更新的元素队列
+      // if (canvas.get('localRefresh')) {
+      //   canvas.refreshElement(element, changeType, canvas);
+      // }
+      // 但对于 https://github.com/antvis/g/issues/422 的场景，全局渲染的模式下也需要记录更新的元素队列
+      canvas.refreshElement(element, changeType, canvas);
       if (canvas.get('autoDraw')) {
         canvas.draw();
       }

--- a/packages/g-canvas/tests/bugs/issue-422-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-422-spec.js
@@ -1,0 +1,38 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { getColor } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#422', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+    pixelRatio: 1,
+    localRefresh: false,
+  });
+
+  const context = canvas.get('context');
+
+  it('should render when localRefresh change from false to true', (done) => {
+    const group = canvas.addGroup();
+    group.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 50,
+        fill: 'red',
+      },
+    });
+
+    canvas.set('localRefresh', true);
+
+    setTimeout(() => {
+      expect(getColor(context, 100, 100)).eqls('#ff0000');
+      done();
+    }, 25);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #422;

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 问题原因: `localRefresh: false` 为全局渲染，不会记录要更新的元素队列 `refreshElements`。但如果将 `localRefresh` 同步修改为 `true` 时，实际采用的却是局部渲染的逻辑，但之前又没有记录 `refreshElements`，因此局部渲染的刷新区域为空，导致实际不会渲染。
- 解决方案: 全局渲染模式下也需要记录更新的元素队列 `refreshElements`，渲染完成后同样需要置空。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix no rendering when localRefresh change from false to true. #422         |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复渲染模式从全局渲染切换到局部渲染时，渲染结果不生效的问题。#422          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
