### PR TITLE
fix(g-base): delay and repeat should work in toAttrs for animate method

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -17,7 +17,7 @@ const ARRAY_ATTRS = {
 
 const CLONE_CFGS = ['zIndex', 'capture', 'visible', 'type'];
 
-const RESERVED_PORPS = ['delay'];
+const RESERVED_PORPS = ['delay', 'repeat'];
 
 const DELEGATION_SPLIT = ':';
 const WILDCARD = '*';
@@ -468,16 +468,19 @@ abstract class Element extends Base implements IElement {
       onFrame = toAttrs as OnFrame;
       toAttrs = {};
     } else if (isObject(toAttrs) && (toAttrs as any).onFrame) {
-      // 兼容 3.0 中的写法，onFrame 可在 toAttrs 中设置
+      // 兼容 3.0 中的写法，onFrame、delay 和 repeat 可在 toAttrs 中设置
       onFrame = (toAttrs as any).onFrame as OnFrame;
+      delay = (toAttrs as any).delay;
+      repeat = (toAttrs as any).repeat;
     }
     // 第二个参数，既可以是执行时间 duration，也可以是动画参数 animateCfg
     if (isObject(duration)) {
       animateCfg = duration as AnimateCfg;
       duration = animateCfg.duration;
       easing = animateCfg.easing || 'easeLinear';
-      delay = animateCfg.delay || 0;
-      repeat = animateCfg.repeat || false;
+      // animateCfg 中的设置优先级更高
+      delay = animateCfg.delay || delay || 0;
+      repeat = animateCfg.repeat || repeat || false;
       callback = animateCfg.callback || noop;
       pauseCallback = animateCfg.pauseCallback || noop;
       resumeCallback = animateCfg.resumeCallback || noop;

--- a/packages/g-base/tests/unit/animate-spec.js
+++ b/packages/g-base/tests/unit/animate-spec.js
@@ -62,7 +62,7 @@ describe('animate', () => {
   });
 
   // 兼容 3.0 中的写法，onFrame 可在 toAttrs 中设置
-  it('animate(toAttrs, duration, easing, callback, delay) and toAttrs has onFrame property', (done) => {
+  it.only('animate(toAttrs, duration, easing, callback, delay) and toAttrs has onFrame, delay and repeat property', (done) => {
     const shape = new Shape({
       attrs: {
         x: 50,
@@ -79,26 +79,25 @@ describe('animate', () => {
             y: 50 + ratio * (100 - 50),
           };
         },
+        delay: 100,
+        repeat: true,
       },
       500,
       'easeLinear',
       () => {
         flag = true;
-      },
-      100
+      }
     );
     expect(shape.attr('x')).eqls(50);
     expect(shape.attr('y')).eqls(50);
     expect(flag).eqls(false);
     setTimeout(() => {
-      expect(flag).eqls(false);
-    }, 550);
-    setTimeout(() => {
-      expect(shape.attr('x')).eqls(100);
-      expect(shape.attr('y')).eqls(100);
-      expect(flag).eqls(true);
+      expect(shape.attr('x')).not.eqls(100);
+      expect(shape.attr('y')).not.eqls(100);
+      expect(shape.get('animating')).eqls(true); // 动画仍然在执行
+      expect(flag).eqls(false); // callback 回调一直得不到执行
       done();
-    }, 1200);
+    }, 700);
   });
 
   it('animate(onFrame, duration, easing, callback, delay)', (done) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix animate method of Element not compatible with `delay` and `repeat` usage in 3.0         |
| 🇨🇳 Chinese | 🐞 [g-base] 兼容 3.0 中动画接口中 `delay` 和 `repeat` 配置的用法。           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
