### PR TITLE
fix(g-base): delay should not work in toAttrs

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -17,7 +17,8 @@ const ARRAY_ATTRS = {
 
 const CLONE_CFGS = ['zIndex', 'capture', 'visible', 'type'];
 
-const RESERVED_PORPS = ['delay', 'repeat'];
+// 可以在 toAttrs 中设置，但不属于绘图属性的字段
+const RESERVED_PORPS = ['repeat'];
 
 const DELEGATION_SPLIT = ':';
 const WILDCARD = '*';
@@ -468,9 +469,8 @@ abstract class Element extends Base implements IElement {
       onFrame = toAttrs as OnFrame;
       toAttrs = {};
     } else if (isObject(toAttrs) && (toAttrs as any).onFrame) {
-      // 兼容 3.0 中的写法，onFrame、delay 和 repeat 可在 toAttrs 中设置
+      // 兼容 3.0 中的写法，onFrame 和 repeat 可在 toAttrs 中设置
       onFrame = (toAttrs as any).onFrame as OnFrame;
-      delay = (toAttrs as any).delay;
       repeat = (toAttrs as any).repeat;
     }
     // 第二个参数，既可以是执行时间 duration，也可以是动画参数 animateCfg
@@ -478,8 +478,8 @@ abstract class Element extends Base implements IElement {
       animateCfg = duration as AnimateCfg;
       duration = animateCfg.duration;
       easing = animateCfg.easing || 'easeLinear';
+      delay = animateCfg.delay || 0;
       // animateCfg 中的设置优先级更高
-      delay = animateCfg.delay || delay || 0;
       repeat = animateCfg.repeat || repeat || false;
       callback = animateCfg.callback || noop;
       pauseCallback = animateCfg.pauseCallback || noop;

--- a/packages/g-base/tests/unit/animate-spec.js
+++ b/packages/g-base/tests/unit/animate-spec.js
@@ -61,8 +61,8 @@ describe('animate', () => {
     }, 700);
   });
 
-  // 兼容 3.0 中的写法，onFrame 可在 toAttrs 中设置
-  it('animate(toAttrs, duration, easing, callback, delay) and toAttrs has onFrame, delay and repeat property', (done) => {
+  // 兼容 3.0 中的写法，onFrame 和 repeat 可在 toAttrs 中设置
+  it('animate(toAttrs, duration, easing, callback, delay) and toAttrs has onFrame and repeat property', (done) => {
     const shape = new Shape({
       attrs: {
         x: 50,
@@ -79,14 +79,14 @@ describe('animate', () => {
             y: 50 + ratio * (100 - 50),
           };
         },
-        delay: 100,
         repeat: true,
       },
       500,
       'easeLinear',
       () => {
         flag = true;
-      }
+      },
+      100
     );
     expect(shape.attr('x')).eqls(50);
     expect(shape.attr('y')).eqls(50);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref PR: #424;

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

-`toAttrs.delay` 不应该生效，原先 3.x 也不支持这种写法，因此 4.0 也不需要兼容。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
