### PR TITLE
fix(text): no rendering for text in IE when maxWidth is nil

### DIFF
--- a/__tests__/unit/canvas/shape/text-spec.js
+++ b/__tests__/unit/canvas/shape/text-spec.js
@@ -440,7 +440,7 @@ describe('Text \n', function() {
     expect(text.attr('textBaseline')).to.equal('top');
     expect(text.attr('lineWidth')).to.equal(1);
   });
-  it('text max-width', () => {
+  it('text maxWidth', () => {
     const text = new G.Text({
       attrs: {
         x: 0,

--- a/src/shapes/text.ts
+++ b/src/shapes/text.ts
@@ -172,7 +172,12 @@ class CText extends Shape {
       if (textArr) {
         self._drawTextArr(context, false);
       } else {
-        context.strokeText(text, x, y, maxWidth);
+        if (!Util.isNil(maxWidth)) {
+          context.strokeText(text, x, y, maxWidth);
+        } else {
+          context.strokeText(text, x, y);
+        }
+        
       }
       context.globalAlpha = 1;
     }
@@ -184,7 +189,12 @@ class CText extends Shape {
       if (textArr) {
         self._drawTextArr(context, true);
       } else {
-        context.fillText(text, x, y, maxWidth);
+        if (!Util.isNil(maxWidth)) {
+          context.fillText(text, x, y, maxWidth);
+        } else {
+          context.fillText(text, x, y);
+        }
+        
       }
     }
     cfg.hasUpdate = false;
@@ -207,9 +217,17 @@ class CText extends Shape {
       if (textBaseline === 'middle') subY += height - fontSize - (height - fontSize) / 2;
       if (textBaseline === 'top') subY += height - fontSize;
       if (fill) {
-        context.fillText(subText, x, subY, maxWidth);
+        if (!Util.isNil(maxWidth)) {
+          context.fillText(subText, x, subY, maxWidth);
+        } else {
+          context.fillText(subText, x, subY);
+        }
       } else {
-        context.strokeText(subText, x, subY, maxWidth);
+        if (!Util.isNil(maxWidth)) {
+          context.strokeText(subText, x, subY, maxWidth);
+        } else {
+          context.strokeText(subText, x, subY);
+        }
       }
     });
   }
@@ -239,7 +257,7 @@ class CText extends Shape {
       width = context.measureText(text).width;
       context.restore();
     }
-    if (attrs.maxWidth !== undefined) {
+    if (!Util.isNil(attrs.maxWidth)) {
       width = Math.min(attrs.maxWidth, width);
     }
     return width;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #429.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 在 IE 浏览器下，对于 Canvas 的 fillText 和 strokeText 接口，maxWidth 为空会影响渲染，因此需要加上判断。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix no rendering for text in IE when maxWidth is nil. #429         |
| 🇨🇳 Chinese | 🐞 修复 Text 的 `maxWidth` 绘图属性为空时，在 IE 浏览器下无法绘制的问题。#429          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
