### PR TITLE
feat(g-canvas): arrow support bbox calculation and hit

### DIFF
--- a/packages/g-base/src/abstract/shape.ts
+++ b/packages/g-base/src/abstract/shape.ts
@@ -148,14 +148,14 @@ abstract class AbstractShape extends Element implements IShape {
       if (this.isInShape(refX, refY)) {
         return true;
       }
-    }
-    // 对起始箭头进行拾取判断
-    if (startArrowShape && startArrowShape.isHit(refX, refY)) {
-      return true;
-    }
-    // 对结束箭头进行拾取判断
-    if (endArrowShape && endArrowShape.isHit(refX, refY)) {
-      return true;
+      // 对起始箭头进行拾取判断
+      if (startArrowShape && startArrowShape.isHit(refX, refY)) {
+        return true;
+      }
+      // 对结束箭头进行拾取判断
+      if (endArrowShape && endArrowShape.isHit(refX, refY)) {
+        return true;
+      }
     }
     return false;
   }

--- a/packages/g-base/src/abstract/shape.ts
+++ b/packages/g-base/src/abstract/shape.ts
@@ -121,6 +121,8 @@ abstract class AbstractShape extends Element implements IShape {
 
   // 不同的 Shape 各自实现
   isHit(x: number, y: number): boolean {
+    const startArrowShape = this.get('startArrowShape');
+    const endArrowShape = this.get('endArrowShape');
     let vec = [x, y, 1];
     vec = this.invertFromMatrix(vec);
     const [refX, refY] = vec;
@@ -131,7 +133,19 @@ abstract class AbstractShape extends Element implements IShape {
     }
     // 被裁减掉的和不在包围盒内的不进行计算
     if (inBBox && !this.isClipped(refX, refY)) {
-      return this.isInShape(refX, refY);
+      // 对图形进行拾取判断
+      if (this.isInShape(refX, refY)) {
+        return true;
+      }
+    }
+
+    // 对起始箭头进行拾取判断
+    if (startArrowShape && startArrowShape.isHit(refX, refY)) {
+      return true;
+    }
+    // 对结束箭头进行拾取判断
+    if (endArrowShape && endArrowShape.isHit(refX, refY)) {
+      return true;
     }
     return false;
   }

--- a/packages/g-base/src/bbox/index.ts
+++ b/packages/g-base/src/bbox/index.ts
@@ -1,7 +1,8 @@
 import { register, getMethod } from './register';
 import rect from './rect';
 import circle from './circle';
-import points from './points';
+import polyline from './polyline';
+import polygon from './polygon';
 import text from './text';
 import path from './path';
 import line from './line';
@@ -11,8 +12,8 @@ register('rect', rect);
 register('image', rect); // image 使用 rect 的包围盒计算
 register('circle', circle);
 register('marker', circle); // marker 使用 circle 的计算方案
-register('polygon', points);
-register('polyline', points);
+register('polyline', polyline);
+register('polygon', polygon);
 register('text', text);
 register('path', path);
 register('line', line);

--- a/packages/g-base/src/bbox/line.ts
+++ b/packages/g-base/src/bbox/line.ts
@@ -1,15 +1,25 @@
 import { SimpleBBox } from '../types';
 import { IShape } from '../interfaces';
+import { mergeArrowBBox } from './util';
 
 export default function(shape: IShape): SimpleBBox {
   const attrs = shape.attr();
   const { x1, y1, x2, y2 } = attrs;
   const minX = Math.min(x1, x2);
+  const maxX = Math.max(x1, x2);
   const minY = Math.min(y1, y2);
+  const maxY = Math.max(y1, y2);
+  let bbox = {
+    minX,
+    maxX,
+    minY,
+    maxY,
+  };
+  bbox = mergeArrowBBox(shape, bbox);
   return {
-    x: minX,
-    y: minY,
-    width: Math.abs(x2 - x1),
-    height: Math.abs(y2 - y1),
+    x: bbox.minX,
+    y: bbox.minY,
+    width: bbox.maxX - bbox.minX,
+    height: bbox.maxY - bbox.minY,
   };
 }

--- a/packages/g-base/src/bbox/path.ts
+++ b/packages/g-base/src/bbox/path.ts
@@ -1,9 +1,11 @@
-import { SimpleBBox } from '../types';
-import { IShape } from '../interfaces';
 import QuadUtil from '@antv/g-math/lib/quadratic';
 import CubicUtil from '@antv/g-math/lib/cubic';
 import EllipseArcUtil from '@antv/g-math/lib/arc';
 import path2Segments from '@antv/path-util/lib/path-2-segments';
+import { SimpleBBox } from '../types';
+import { IShape } from '../interfaces';
+import { mergeArrowBBox } from './util';
+
 function getPathBox(segments, lineWidth) {
   let xArr = [];
   let yArr = [];
@@ -127,5 +129,18 @@ export default function(shape: IShape): SimpleBBox {
   const { path, stroke } = attrs;
   const lineWidth = stroke ? attrs.lineWidth : 0; // 只有有 stroke 时，lineWidth 才生效
   const segments = shape.get('segments') || path2Segments(path);
-  return getPathBox(segments, lineWidth);
+  const { x, y, width, height } = getPathBox(segments, lineWidth);
+  let bbox = {
+    minX: x,
+    minY: y,
+    maxX: x + width,
+    maxY: y + height,
+  };
+  bbox = mergeArrowBBox(shape, bbox);
+  return {
+    x: bbox.minX,
+    y: bbox.minY,
+    width: bbox.maxX - bbox.minX,
+    height: bbox.maxY - bbox.minY,
+  };
 }

--- a/packages/g-base/src/bbox/points.ts
+++ b/packages/g-base/src/bbox/points.ts
@@ -1,6 +1,7 @@
 import { getBBoxByArray } from '@antv/g-math/lib/util';
 import { SimpleBBox } from '../types';
 import { IShape } from '../interfaces';
+import { mergeArrowBBox } from './util';
 
 export default function(shape: IShape): SimpleBBox {
   const attrs = shape.attr();
@@ -12,5 +13,18 @@ export default function(shape: IShape): SimpleBBox {
     xArr.push(point[0]);
     yArr.push(point[1]);
   }
-  return getBBoxByArray(xArr, yArr);
+  const { x, y, width, height } = getBBoxByArray(xArr, yArr);
+  let bbox = {
+    minX: x,
+    maxX: y,
+    minY: x + width,
+    maxY: y + height,
+  };
+  bbox = mergeArrowBBox(shape, bbox);
+  return {
+    x: bbox.minX,
+    y: bbox.minY,
+    width: bbox.maxX - bbox.minX,
+    height: bbox.maxY - bbox.minY,
+  };
 }

--- a/packages/g-base/src/bbox/polygon.ts
+++ b/packages/g-base/src/bbox/polygon.ts
@@ -1,0 +1,16 @@
+import { getBBoxByArray } from '@antv/g-math/lib/util';
+import { SimpleBBox } from '../types';
+import { IShape } from '../interfaces';
+
+export default function(shape: IShape): SimpleBBox {
+  const attrs = shape.attr();
+  const { points } = attrs;
+  const xArr = [];
+  const yArr = [];
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i];
+    xArr.push(point[0]);
+    yArr.push(point[1]);
+  }
+  return getBBoxByArray(xArr, yArr);
+}

--- a/packages/g-base/src/bbox/polyline.ts
+++ b/packages/g-base/src/bbox/polyline.ts
@@ -16,8 +16,8 @@ export default function(shape: IShape): SimpleBBox {
   const { x, y, width, height } = getBBoxByArray(xArr, yArr);
   let bbox = {
     minX: x,
-    maxX: y,
-    minY: x + width,
+    minY: y,
+    maxX: x + width,
     maxY: y + height,
   };
   bbox = mergeArrowBBox(shape, bbox);

--- a/packages/g-base/src/bbox/util.ts
+++ b/packages/g-base/src/bbox/util.ts
@@ -1,0 +1,32 @@
+import { IShape } from '../interfaces';
+import { BBox, SimpleBBox } from '../types';
+
+// 合并包围盒
+export function mergeBBox(bbox1, bbox2) {
+  if (!bbox1 || !bbox2) {
+    return bbox1 || bbox2;
+  }
+  return {
+    minX: Math.min(bbox1.minX, bbox2.minX),
+    minY: Math.min(bbox1.minY, bbox2.minY),
+    maxX: Math.max(bbox1.maxX, bbox2.maxX),
+    maxY: Math.max(bbox1.maxY, bbox2.maxY),
+  };
+}
+
+// 合并箭头的包围盒
+export function mergeArrowBBox(shape: IShape, bbox) {
+  const startArrowShape = shape.get('startArrowShape');
+  const endArrowShape = shape.get('endArrowShape');
+  let startArrowBBox = null;
+  let endArrowBBox = null;
+  if (startArrowShape) {
+    startArrowBBox = startArrowShape.getCanvasBBox();
+    bbox = mergeBBox(bbox, startArrowBBox);
+  }
+  if (endArrowShape) {
+    endArrowBBox = endArrowShape.getCanvasBBox();
+    bbox = mergeBBox(bbox, endArrowBBox);
+  }
+  return bbox;
+}

--- a/packages/g-canvas/src/shape/line.ts
+++ b/packages/g-canvas/src/shape/line.ts
@@ -21,6 +21,28 @@ class Line extends ShapeBase {
     };
   }
 
+  initAttrs(attrs) {
+    this.setArrow();
+  }
+
+  // 更新属性时，检测是否更改了箭头
+  onAttrChange(name: string, value: any, originValue: any) {
+    super.onAttrChange(name, value, originValue);
+    // 由于箭头的绘制依赖于 line 的诸多 attrs，因此这里不再对每个 attr 进行判断，attr 每次变化都会影响箭头的更新
+    this.setArrow();
+  }
+
+  setArrow() {
+    const attrs = this.attr();
+    const { x1, y1, x2, y2, startArrow, endArrow } = attrs;
+    if (startArrow) {
+      ArrowUtil.addStartArrow(this, attrs, x2, y2, x1, y1);
+    }
+    if (endArrow) {
+      ArrowUtil.addEndArrow(this, attrs, x1, y1, x2, y2);
+    }
+  }
+
   isInStrokeOrPath(x, y, isStroke, isFill, lineWidth) {
     if (!isStroke || !lineWidth) {
       return false;
@@ -55,13 +77,13 @@ class Line extends ShapeBase {
   }
 
   afterDrawPath(context) {
-    const attrs = this.attr();
-    const { x1, y1, x2, y2 } = attrs;
-    if (attrs.startArrow) {
-      ArrowUtil.addStartArrow(context, attrs, x2, y2, x1, y1);
+    const startArrowShape = this.get('startArrowShape');
+    const endArrowShape = this.get('endArrowShape');
+    if (startArrowShape) {
+      startArrowShape.draw(context);
     }
-    if (attrs.endArrow) {
-      ArrowUtil.addEndArrow(context, attrs, x1, y1, x2, y2);
+    if (endArrowShape) {
+      endArrowShape.draw(context);
     }
   }
 

--- a/packages/g-canvas/src/shape/polyline.ts
+++ b/packages/g-canvas/src/shape/polyline.ts
@@ -20,9 +20,14 @@ class PolyLine extends ShapeBase {
     };
   }
 
+  initAttrs(attrs) {
+    this.setArrow();
+  }
+
   // 更新属性时，检测是否更改了 points
   onAttrChange(name: string, value: any, originValue: any) {
     super.onAttrChange(name, value, originValue);
+    this.setArrow();
     if (['points'].indexOf(name) !== -1) {
       this._resetCache();
     }
@@ -31,6 +36,23 @@ class PolyLine extends ShapeBase {
   _resetCache() {
     this.set('totalLength', null);
     this.set('tCache', null);
+  }
+
+  setArrow() {
+    const attrs = this.attr();
+    const { points, startArrow, endArrow } = this.attrs;
+    const length = points.length;
+    const x1 = points[0][0];
+    const y1 = points[0][1];
+    const x2 = points[length - 1][0];
+    const y2 = points[length - 1][1];
+
+    if (startArrow) {
+      ArrowUtil.addStartArrow(this, attrs, points[1][0], points[1][1], x1, y1);
+    }
+    if (endArrow) {
+      ArrowUtil.addEndArrow(this, attrs, points[length - 2][0], points[length - 2][1], x2, y2);
+    }
   }
 
   // 不允许 fill
@@ -84,19 +106,13 @@ class PolyLine extends ShapeBase {
   }
 
   afterDrawPath(context: CanvasRenderingContext2D) {
-    const attrs = this.attr();
-    const { points, startArrow, endArrow } = this.attrs;
-    const length = points.length;
-    const x1 = points[0][0];
-    const y1 = points[0][1];
-    const x2 = points[length - 1][0];
-    const y2 = points[length - 1][1];
-
-    if (startArrow) {
-      ArrowUtil.addStartArrow(context, attrs, points[1][0], points[1][1], x1, y1);
+    const startArrowShape = this.get('startArrowShape');
+    const endArrowShape = this.get('endArrowShape');
+    if (startArrowShape) {
+      startArrowShape.draw(context);
     }
-    if (endArrow) {
-      ArrowUtil.addEndArrow(context, attrs, points[length - 2][0], points[length - 2][1], x2, y2);
+    if (endArrowShape) {
+      endArrowShape.draw(context);
     }
   }
 

--- a/packages/g-canvas/tests/bugs/issue-432-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-432-spec.js
@@ -1,0 +1,266 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { getTextColorCount } from '../get-color';
+import { simulateMouseEvent, getClientPoint } from '../util';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#432', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 1000,
+    height: 1000,
+    pixelRatio: 1,
+  });
+
+  const context = canvas.get('context');
+  const el = canvas.get('el');
+
+  it('default arrow for Line should be rendered and hit when localRefresh is true', (done) => {
+    const line = canvas.addShape('line', {
+      attrs: {
+        x1: 100,
+        y1: 100,
+        x2: 200,
+        y2: 100,
+        stroke: 'red',
+        startArrow: true,
+        endArrow: true,
+      },
+    });
+
+    setTimeout(() => {
+      expect(getTextColorCount(context, 100, 96, 20, '#ff0000') > 0).eqls(true);
+
+      let clickCalled = false;
+      line.on('click', () => {
+        clickCalled = true;
+      });
+      const { clientX, clientY } = getClientPoint(
+        canvas,
+        100 + 10 * Math.cos(Math.PI / 6),
+        100 - 10 * Math.sin(Math.PI / 6)
+      );
+      simulateMouseEvent(el, 'mousedown', {
+        clientX,
+        clientY,
+      });
+      simulateMouseEvent(el, 'mouseup', {
+        clientX,
+        clientY,
+      });
+      expect(clickCalled).eqls(true);
+
+      done();
+    }, 25);
+  });
+
+  it('customized arrow for Line should be rendered and hit when localRefresh is true', (done) => {
+    const line = canvas.addShape('line', {
+      attrs: {
+        x1: 200,
+        y1: 200,
+        x2: 300,
+        y2: 200,
+        stroke: 'red',
+        startArrow: {
+          path: 'M 10,10 L 0,0 L 10,-10',
+        },
+        endArrow: {
+          path: 'M 10,10 L 0,0 L 10,-10',
+        },
+      },
+    });
+
+    setTimeout(() => {
+      expect(getTextColorCount(context, 200, 196, 20, '#ff0000') > 0).eqls(true);
+
+      let clickCalled = false;
+      line.on('click', () => {
+        clickCalled = true;
+      });
+      const { clientX, clientY } = getClientPoint(canvas, 200 + 10, 200 - 10);
+      simulateMouseEvent(el, 'mousedown', {
+        clientX,
+        clientY,
+      });
+      simulateMouseEvent(el, 'mouseup', {
+        clientX,
+        clientY,
+      });
+      expect(clickCalled).eqls(true);
+
+      done();
+    }, 25);
+  });
+
+  it('default arrow for Polyline should be rendered and hit when localRefresh is true', (done) => {
+    const polyline = canvas.addShape('polyline', {
+      attrs: {
+        points: [
+          [250, 250],
+          [300, 250],
+          [300, 300],
+          [350, 300],
+          [350, 350],
+          [400, 350],
+        ],
+        stroke: 'red',
+        startArrow: true,
+        endArrow: true,
+      },
+    });
+
+    setTimeout(() => {
+      expect(getTextColorCount(context, 250, 246, 20, '#ff0000') > 0).eqls(true);
+
+      let clickCalled = false;
+      polyline.on('click', () => {
+        clickCalled = true;
+      });
+      const { clientX, clientY } = getClientPoint(
+        canvas,
+        250 + 10 * Math.cos(Math.PI / 6),
+        250 - 10 * Math.sin(Math.PI / 6)
+      );
+      simulateMouseEvent(el, 'mousedown', {
+        clientX,
+        clientY,
+      });
+      simulateMouseEvent(el, 'mouseup', {
+        clientX,
+        clientY,
+      });
+      expect(clickCalled).eqls(true);
+
+      done();
+    }, 25);
+  });
+
+  it('customized arrow for Polyline should be rendered and hit when localRefresh is true', (done) => {
+    const polyline = canvas.addShape('polyline', {
+      attrs: {
+        points: [
+          [150, 250],
+          [200, 250],
+          [200, 300],
+          [250, 300],
+          [250, 350],
+          [300, 350],
+        ],
+        stroke: 'red',
+        startArrow: {
+          path: 'M 10,10 L 0,0 L 10,-10',
+        },
+        endArrow: {
+          path: 'M 10,10 L 0,0 L 10,-10',
+        },
+      },
+    });
+
+    setTimeout(() => {
+      expect(getTextColorCount(context, 150, 246, 20, '#ff0000') > 0).eqls(true);
+
+      let clickCalled = false;
+      polyline.on('click', () => {
+        clickCalled = true;
+      });
+      const { clientX, clientY } = getClientPoint(canvas, 150 + 10, 250 - 10);
+      simulateMouseEvent(el, 'mousedown', {
+        clientX,
+        clientY,
+      });
+      simulateMouseEvent(el, 'mouseup', {
+        clientX,
+        clientY,
+      });
+      expect(clickCalled).eqls(true);
+
+      done();
+    }, 25);
+  });
+
+  it('default arrow for Path should be rendered and hit when localRefresh is true', (done) => {
+    const path = canvas.addShape('path', {
+      attrs: {
+        path: [
+          ['M', 100, 800],
+          ['L', 300, 800],
+          ['L', 200, 900],
+          ['L', 400, 900],
+        ],
+        stroke: 'red',
+        startArrow: true,
+        endArrow: true,
+      },
+    });
+
+    setTimeout(() => {
+      expect(getTextColorCount(context, 100, 796, 20, '#ff0000') > 0).eqls(true);
+
+      let clickCalled = false;
+      path.on('click', () => {
+        clickCalled = true;
+      });
+      const { clientX, clientY } = getClientPoint(
+        canvas,
+        100 + 10 * Math.cos(Math.PI / 6),
+        800 - 10 * Math.sin(Math.PI / 6)
+      );
+      simulateMouseEvent(el, 'mousedown', {
+        clientX,
+        clientY,
+      });
+      simulateMouseEvent(el, 'mouseup', {
+        clientX,
+        clientY,
+      });
+      expect(clickCalled).eqls(true);
+
+      done();
+    }, 25);
+  });
+
+  it('customized arrow for Path should be rendered and hit when localRefresh is true', (done) => {
+    const path = canvas.addShape('path', {
+      attrs: {
+        path: [
+          ['M', 500, 800],
+          ['L', 700, 800],
+          ['L', 600, 900],
+          ['L', 800, 900],
+        ],
+        stroke: 'red',
+        startArrow: {
+          path: 'M 10,10 L 0,0 L 10,-10',
+        },
+        endArrow: {
+          path: 'M 10,10 L 0,0 L 10,-10',
+        },
+      },
+    });
+
+    setTimeout(() => {
+      expect(getTextColorCount(context, 500, 796, 20, '#ff0000') > 0).eqls(true);
+
+      let clickCalled = false;
+      path.on('click', () => {
+        clickCalled = true;
+      });
+      const { clientX, clientY } = getClientPoint(canvas, 500 + 10, 800 - 10);
+      simulateMouseEvent(el, 'mousedown', {
+        clientX,
+        clientY,
+      });
+      simulateMouseEvent(el, 'mouseup', {
+        clientX,
+        clientY,
+      });
+      expect(clickCalled).eqls(true);
+
+      done();
+    }, 25);
+  });
+});

--- a/packages/g-canvas/tests/bugs/issue-436-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-436-spec.js
@@ -32,6 +32,6 @@ describe('#436', () => {
     expect(bbox.minX).eqls(53.88829007174579);
     expect(bbox.minY).eqls(77.53153216848064);
     expect(bbox.maxX).eqls(870.5);
-    expect(bbox.maxY).eqls(122.46846783151936);
+    expect(bbox.maxY).eqls(128.46846783151938);
   });
 });

--- a/packages/g-canvas/tests/unit/shape/polyline-spec.js
+++ b/packages/g-canvas/tests/unit/shape/polyline-spec.js
@@ -7,7 +7,7 @@ canvas.height = 300;
 document.body.appendChild(canvas);
 const ctx = canvas.getContext('2d');
 
-describe('polygon test', () => {
+describe('polyline test', () => {
   const points1 = [
     [10, 10],
     [100, 10],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Ref: #432.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 箭头的包围盒最后决定还是放 bbox 了，毕竟也是图形的一部分。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🌟 [g-canvas] Arrow support for bbox calculation and hit. #432          |
| 🇨🇳 Chinese | 🌟 [g-canvas] 箭头支持包围盒计算和拾取。#432           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
