### PR TITLE
fix(g-canvas): fill attr should work for custom arrow

### DIFF
--- a/packages/g-canvas/src/util/arrow.ts
+++ b/packages/g-canvas/src/util/arrow.ts
@@ -52,9 +52,11 @@ function _addCustomizedArrow(shape, attrs, x1, y1, x2, y2, isStart) {
     isArrowShape: true,
     attrs: {
       ...restAttrs,
-      // 支持单独设置箭头的 stroke，若为空则使用 shape 的值
+      // 支持单独设置箭头的 stroke 和 lineWidth，若为空则使用 shape 的值
       stroke: arrowStroke || stroke,
       lineWidth: arrowLineWidth || lineWidth,
+      // 箭头是否填充需要手动设置，不会继承自 shape 的值
+      fill: arrowFill,
     },
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix `fill` attr not work for custom arrow.  |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复自定义箭头的 `fill` 绘图属性不生效的问题。           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
