### PR TITLE
fix(g-base): fix an condition judgement type error in path util

### DIFF
--- a/packages/g-base/src/util/path.ts
+++ b/packages/g-base/src/util/path.ts
@@ -1189,7 +1189,7 @@ const fillPathByDiff = function(source, target) {
   let index = 1;
   let minPos = 1;
   // 如果source和target不是完全不相等
-  if (diffMatrix[sourceLen][targetLen] !== sourceLen) {
+  if (diffMatrix[sourceLen][targetLen].min !== sourceLen) {
     // 获取从source到target所需改动
     for (let i = 1; i <= sourceLen; i++) {
       let min = diffMatrix[i][i].min;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The left side of the equation is an object while the right side is a number, which means they will never be equal. It seems a `.min` is missed for the levenshtein distance          |
| 🇨🇳 Chinese | 此处判断等号左边是对象，右边是数字永远不相等，从上下文看含义是取莱文斯坦距离，应该是漏写了`.min`          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
