### PR TITLE
fix(g-base): dragenter & dragleave event should be able to bubble

### DIFF
--- a/packages/g-base/src/event/event-contoller.ts
+++ b/packages/g-base/src/event/event-contoller.ts
@@ -71,10 +71,10 @@ function bubbleEvent(container, type, eventObj) {
   if (eventObj.bubbles) {
     let relativeShape;
     let isOverEvent = false;
-    if (type === 'mouseenter' || type === 'dragenter') {
+    if (type === 'mouseenter') {
       relativeShape = eventObj.fromShape;
       isOverEvent = true;
-    } else if (type === 'mouseleave' || type === 'dragleave') {
+    } else if (type === 'mouseleave') {
       isOverEvent = true;
       relativeShape = eventObj.toShape;
     }
@@ -192,7 +192,7 @@ class EventController {
       method.call(this, pointInfo, shape, ev);
     } else {
       const preShape = this.currentShape;
-      // 如果进入、移出画布时存在图形，则要分别出发事件
+      // 如果进入、移出画布时存在图形，则要分别触发事件
       if (type === 'mouseenter' || type === 'dragenter' || type === 'mouseover') {
         this._emitEvent(type, ev, pointInfo, null, null, shape); // 先进入画布
         if (shape) {
@@ -308,6 +308,7 @@ class EventController {
         this._emitEvent('dragover', event, pointInfo, toShape);
       }
     } else if (fromShape) {
+      // TODO: 此处判断有问题，当 drag 图形时，也会触发一次 dragleave 事件，因为此时 toShape 为 null，这不是所期望的
       // 经过空白区域
       this._emitEvent('dragleave', event, pointInfo, fromShape, fromShape, toShape);
     }
@@ -356,7 +357,7 @@ class EventController {
     }
   }
 
-  // 当触发浏览器的 dragover 事件时，不会再触发mousemove ，所以这时候的 dragenter, dragleave 事件需要重新处理
+  // 当触发浏览器的 dragover 事件时，不会再触发 mousemove ，所以这时候的 dragenter, dragleave 事件需要重新处理
   _ondragover(pointInfo, shape, event) {
     event.preventDefault(); // 如果不对 dragover 进行 preventDefault，则不会在 canvas 上触发 drop 事件
     const preShape = this.currentShape;

--- a/packages/g-canvas/tests/bugs/issue-456-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-456-spec.js
@@ -1,0 +1,109 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { simulateMouseEvent, getClientPoint } from '../util';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#456', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 1000,
+    height: 400,
+  });
+
+  const el = canvas.get('el');
+
+  it('dragenter & dragleave event should be able to bubble', () => {
+    // rect1
+    canvas.addShape('rect', {
+      name: 'rect1',
+      attrs: {
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+        fill: '#f00',
+      },
+    });
+
+    // rect2
+    const rect2 = canvas.addShape('rect', {
+      draggable: true,
+      name: 'rect2',
+      attrs: {
+        x: 0,
+        y: 100,
+        width: 50,
+        height: 50,
+        fill: '#ff0',
+      },
+    });
+
+    let dragCalled = false;
+    let dragenterCalled = false;
+    let dragoverCalled = false;
+    let dragleaveCalled = false;
+
+    canvas.on('dragenter', () => {
+      dragenterCalled = true;
+    });
+
+    canvas.on('dragover', () => {
+      dragoverCalled = true;
+    });
+
+    canvas.on('dragleave', () => {
+      dragleaveCalled = true;
+    });
+
+    canvas.on('rect2:drag', (e) => {
+      dragCalled = true;
+      rect2.attr({
+        x: e.x - 10,
+        y: e.y - 10,
+      });
+    });
+
+    const { clientX, clientY } = getClientPoint(canvas, 25, 125);
+    // 鼠标按下
+    simulateMouseEvent(el, 'mousedown', {
+      clientX,
+      clientY,
+    });
+    // 鼠标移动，触发 dragstart 事件
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 10,
+      clientY,
+    });
+    // 鼠标再次移动，才会触发 drag 事件
+    // 要模拟 drag 事件，需要触发 mousemove 事件两次以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 20,
+      clientY,
+    });
+    expect(dragCalled).eqls(true);
+
+    // 拖拽从下边缘进入 rect1
+    simulateMouseEvent(el, 'mousemove', {
+      clientX,
+      clientY: clientY - 80,
+    });
+    expect(dragenterCalled).eqls(true);
+
+    // 在 rect1 中拖拽
+    simulateMouseEvent(el, 'mousemove', {
+      clientX,
+      clientY: clientY - 100,
+    });
+    expect(dragoverCalled).eqls(true);
+
+    // 拖拽从右边缘离开 rect1
+    simulateMouseEvent(el, 'mousemove', {
+      clientX: clientX + 50,
+      clientY: clientY - 100,
+    });
+    expect(dragleaveCalled).eqls(true);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #456.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 根据 MDN 对 [dragenter](https://developer.mozilla.org/zh-CN/docs/Web/API/Document/dragenter_event) 和 [dragleave](https://developer.mozilla.org/zh-CN/docs/Web/API/Document/dragleave_event) 事件规范的描述和定义，这两个事件可以冒泡。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-base] Fix that `dragenter` and `dragleave` events are unable to bubble. #456         |
| 🇨🇳 Chinese | 🐞 [g-base] 修复 `dragenter` 和 `dragleave` 事件无法冒泡的问题。#456          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
