### PR TITLE
fix(g-base): set animation._paused to true in element.pauseAnimate()

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -557,9 +557,10 @@ abstract class Element extends Base implements IElement {
   pauseAnimate() {
     const timeline = this.get('timeline');
     const animations = this.get('animations');
+    const pauseTime = timeline.getTime();
     each(animations, (animation: Animation) => {
       animation._paused = true;
-      animation._pauseTime = timeline.getTime();
+      animation._pauseTime = pauseTime;
       if (animation.pauseCallback) {
         // 动画暂停时的回调
         animation.pauseCallback();
@@ -568,7 +569,7 @@ abstract class Element extends Base implements IElement {
     // 记录下是在什么时候暂停的
     this.set('_pause', {
       isPaused: true,
-      pauseTime: timeline.getTime(),
+      pauseTime,
     });
     return this;
   }

--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -558,6 +558,8 @@ abstract class Element extends Base implements IElement {
     const timeline = this.get('timeline');
     const animations = this.get('animations');
     each(animations, (animation: Animation) => {
+      animation._paused = true;
+      animation._pauseTime = timeline.getTime();
       if (animation.pauseCallback) {
         // 动画暂停时的回调
         animation.pauseCallback();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/antvis/g/issues/451
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
原先在 element.pauseAnimate()中，仅通过 this.set('_pause', ...) 将 cfg._pase.isPaused 设置为 true ，但并未将 animation._paused 设置为 true 。
animation._paused 是一个优化更新性能的判断标记，仅在以下一处使用： https://github.com/antvis/g/blob/0e1fcb57c85ca1e1bc4d516b12791f05364af71b/packages/g-base/src/animate/timeline.ts#L91 
因此就算从未被设置为 true 也不会影响逻辑和测试，但就起不到优化的作用。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | set animation._paused to true in element.pauseAnimate() |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
