### PR TITLE
fix(g-svg): should not handle fontSize < 12 for text

### DIFF
--- a/packages/g-svg/src/shape/text.ts
+++ b/packages/g-svg/src/shape/text.ts
@@ -77,7 +77,7 @@ class Text extends ShapeBase {
 
   _setFont() {
     const el = this.get('el');
-    const { fontSize, textBaseline, textAlign } = this.attr();
+    const { textBaseline, textAlign } = this.attr();
 
     const browser = detect();
     if (browser && browser.name === 'firefox') {
@@ -88,11 +88,6 @@ class Text extends ShapeBase {
     }
 
     el.setAttribute('text-anchor', ANCHOR_MAP[textAlign] || 'left');
-    if (fontSize && +fontSize < 12) {
-      // 小于 12 像素的文本进行 scale 处理
-      this.attr('matrix', [1, 0, 0, 0, 1, 0, 0, 0, 1]);
-      this.transform();
-    }
   }
 
   _setText(text) {

--- a/packages/g-svg/tests/bugs/issue-465-spec.js
+++ b/packages/g-svg/tests/bugs/issue-465-spec.js
@@ -1,0 +1,29 @@
+const expect = require('chai').expect;
+import Canvas from '../../../g-svg/src/canvas';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+
+describe('#465', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+  });
+
+  it('text of fontSize < 12 should be rendered', () => {
+    const text = canvas.addShape('text', {
+      attrs: {
+        x: 50,
+        y: 100,
+        fontFamily: 'PingFang SC',
+        text: '文本文本',
+        fontSize: 10,
+        stroke: 'red',
+      },
+    });
+    const el = text.get('el');
+    expect(el.getAttribute('stroke')).eqls('red');
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #465.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 原先的逻辑应该是为了处理浏览器对 12px 字体的最小限制而做的 scale 处理，但实际测试下来，小于 12px 的字体在浏览器中也能正常渲染。再加上由于现在默认是自动渲染机制，做 scale 处理之后会不断触发字体渲染，导致死循环。因此去掉这一逻辑。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-svg] Fix text not rendered when `fontSize` < 12. #465           |
| 🇨🇳 Chinese | 🐞 [g-svg] 修复字体小于 `12px` 的文本无法正常渲染的问题。#465          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
