### PR TITLE
fix: prevent undefined error when check isParent

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -619,7 +619,12 @@ abstract class Element extends Base implements IElement {
       const name = element.get('name');
       if (name) {
         // 第一个 mouseenter 和 mouseleave 的停止即可，因为后面的都是前面的 Parent
-        if (relativeShape && isParent(element, relativeShape)) {
+        if (
+          // 只有 element 是 Group 或者 Canvas 的时候，才需要判断 isParent
+          (element.isGroup() || (element.isCanvas && element.isCanvas())) &&
+          relativeShape &&
+          isParent(element, relativeShape)
+        ) {
           break;
         }
         // 事件委托的形式 name:type


### PR DESCRIPTION
在处理 mouseenter/mouseleave 的时候会不稳定出现错误，实际上这里检查 isParent 就暗示需要当前 element 是 Group 或者 Canvas了：

![image](https://user-images.githubusercontent.com/1142242/78857789-eec9bd80-7a5c-11ea-9b79-39fcb41ae25c.png)
