### PR TITLE
fix: 添加空判断，防止报错

### DIFF
--- a/packages/g-base/src/abstract/element.ts
+++ b/packages/g-base/src/abstract/element.ts
@@ -350,7 +350,9 @@ abstract class Element extends Base implements IElement {
     const matrix = this.attr('matrix');
     if (matrix) {
       const invertMatrix = invert(matrix);
-      return multiplyVec2(invertMatrix, v);
+      if (invertMatrix) {
+        return multiplyVec2(invertMatrix, v);
+      }
     }
     return v;
   }


### PR DESCRIPTION
在 G2，当传入空数据进行绘制图表后，鼠标在图表上移动会报错。