### PR TITLE
fix(gl-matrix): use gl-matrix instead of antv/gl-matrix

### DIFF
--- a/packages/g-base/package.json
+++ b/packages/g-base/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/antvis/util/issues"
   },
   "devDependencies": {
-    "@antv/gl-matrix": "~2.7.1",
+    "gl-matrix": "^3.0.0",
     "@antv/torch": "^1.0.0",
     "less": "^3.9.0",
     "npm-run-all": "^4.1.5",

--- a/packages/g-canvas/package.json
+++ b/packages/g-canvas/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@antv/g-base": "^0.4.3",
     "@antv/g-math": "^0.1.2",
-    "@antv/gl-matrix": "~2.7.1",
+    "gl-matrix": "^3.0.0",
     "@antv/path-util": "~2.0.5",
     "@antv/util": "~2.0.0"
   },

--- a/packages/g-canvas/src/util/path.ts
+++ b/packages/g-canvas/src/util/path.ts
@@ -11,8 +11,8 @@ import { inBox, isSamePoint } from './util';
 import inLine from './in-stroke/line';
 import inArc from './in-stroke/arc';
 
-import * as mat3 from '@antv/gl-matrix/lib/gl-matrix/mat3';
-import * as vec3 from '@antv/gl-matrix/lib/gl-matrix/vec3';
+import * as mat3 from 'gl-matrix/mat3';
+import * as vec3 from 'gl-matrix/vec3';
 
 function hasArc(path) {
   let hasArc = false;

--- a/packages/g-math/package.json
+++ b/packages/g-math/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/antvis/util#readme",
   "dependencies": {
-    "@antv/gl-matrix": "~2.7.1",
+    "gl-matrix": "^3.0.0",
     "@antv/util": "~2.0.0"
   }
 }

--- a/packages/g-math/src/line.ts
+++ b/packages/g-math/src/line.ts
@@ -1,5 +1,5 @@
 import { distance, getBBoxByArray } from './util';
-import * as vec2 from '@antv/gl-matrix/lib/gl-matrix/vec2';
+import * as vec2 from 'gl-matrix/vec2';
 import { BBox, Point } from './types';
 
 export default {


### PR DESCRIPTION
ref https://github.com/antvis/util/pull/37 、 https://github.com/antvis/G2/issues/2317

 - [x] gl-matrix 已经支持按需加载，且提供自己的类型定义，所以无需使用 fork 的 @antvis/gl-matrix 了

> 另外，可以设置 [antvis/gl-matrix](https://github.com/antvis/gl-matrix) Archive 掉，不用在维护了。