### PR TITLE
fix(hit): canvas is not a group

### DIFF
--- a/packages/g-canvas/src/util/hit.ts
+++ b/packages/g-canvas/src/util/hit.ts
@@ -22,7 +22,7 @@ function getRefXY(element: IElement, x: number, y: number) {
 // 拾取前的检测，只有通过检测才能继续拾取
 function preTest(element: IElement, x: number, y: number) {
   // @ts-ignore
-  if (element.isGroup() && element.isCanvas()) {
+  if (element.isCanvas && element.isCanvas()) {
     return true;
   }
   // 不允许被拾取，则返回 null
@@ -38,7 +38,10 @@ function preTest(element: IElement, x: number, y: number) {
     }
   }
   // @ts-ignore ，这个地方调用过于频繁
-  const bbox = element.cfg.cacheCanvasBBox || element.getCanvasBBox();
+  let bbox = element.cfg.cacheCanvasBBox;
+  if (!bbox) {
+    bbox = element.getCanvasBBox();
+  }
   if (!(x >= bbox.minX && x <= bbox.maxX && y >= bbox.minY && y <= bbox.maxY)) {
     return false;
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
这个地方判定出问题了，导致 canvas.getCanvasBBox 在每次拾取的时候调用，性能极大降低。