### PR TITLE
fix(g-canvas): render should work correctly when element is clipped by view

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "@commitlint/config-angular": "^8.3.4",
     "@types/lodash": "^4.14.119",
     "@types/node": "^10.12.18",
-    "@types/react": "^16.9.2",
-    "@types/react-dom": "^16.9.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.4",
     "benchmark": "^2.1.4",

--- a/packages/g-canvas/src/group.ts
+++ b/packages/g-canvas/src/group.ts
@@ -4,7 +4,6 @@ import { IElement } from './interfaces';
 import { Region } from './types';
 import ShapeBase from './shape/base';
 import * as Shape from './shape';
-import { each, mergeRegion } from './util/util';
 import { applyAttrsToContext, drawChildren, refreshElement } from './util/draw';
 
 class Group extends AbstractGroup {

--- a/packages/g-canvas/src/shape/base.ts
+++ b/packages/g-canvas/src/shape/base.ts
@@ -90,6 +90,8 @@ class ShapeBase extends AbstractShape {
       // 是否相交需要考虑 clip 的包围盒
       const bbox = clip ? getMergedRegion([this, clip]) : this.getCanvasBBox();
       if (!intersectRect(region, bbox)) {
+        // 图形的包围盒与重绘区域不相交时，也需要清除标记
+        this.set('hasChanged', false);
         return;
       }
     }

--- a/packages/g-canvas/tests/bugs/issue-380-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-380-spec.js
@@ -28,7 +28,7 @@ describe('#380', () => {
       clientY,
     });
 
-    // 要模拟 drag 事件，需要触发 mousemove 事件两次以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
+    // 要模拟 drag 事件，需要触发 mousemove 事件两次及以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
     simulateMouseEvent(el, 'mousemove', {
       clientX: clientX + 20,
       clientY,

--- a/packages/g-canvas/tests/bugs/issue-456-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-456-spec.js
@@ -78,7 +78,7 @@ describe('#456', () => {
       clientY,
     });
     // 鼠标再次移动，才会触发 drag 事件
-    // 要模拟 drag 事件，需要触发 mousemove 事件两次以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
+    // 要模拟 drag 事件，需要触发 mousemove 事件两次及以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
     simulateMouseEvent(el, 'mousemove', {
       clientX: clientX + 20,
       clientY,

--- a/packages/g-canvas/tests/bugs/issue-494-spec.js
+++ b/packages/g-canvas/tests/bugs/issue-494-spec.js
@@ -1,0 +1,120 @@
+const expect = require('chai').expect;
+import Canvas from '../../src/canvas';
+import { simulateMouseEvent, getClientPoint } from '../util';
+import { getColor } from '../get-color';
+
+const dom = document.createElement('div');
+document.body.appendChild(dom);
+dom.id = 'c1';
+dom.style.border = '1px solid black';
+dom.style.display = 'inline-block';
+
+describe('#494', () => {
+  const canvas = new Canvas({
+    container: dom,
+    width: 400,
+    height: 400,
+  });
+
+  const el = canvas.get('el');
+  const context = canvas.get('context');
+  const pixelRatio = canvas.getPixelRatio();
+
+  it('render should work correctly when element is clipped by view', (done) => {
+    const group = canvas.addGroup();
+    const rect = group.addShape('rect', {
+      draggable: true,
+      attrs: {
+        fill: 'red',
+        stroke: 'blue',
+        lineWidth: 4,
+        height: 40,
+        width: 40,
+        x: 100,
+        y: 100,
+      },
+    });
+
+    canvas.on('click', () => {
+      group.translate(0, 200);
+    });
+
+    let origin = {};
+
+    rect.on('dragstart', (e) => {
+      origin = {
+        x: e.clientX,
+        y: e.clientY,
+      };
+    });
+
+    rect.on('drag', (e) => {
+      const clientX = +e.clientX;
+      const clientY = +e.clientY;
+      if (isNaN(clientX) || isNaN(clientY)) {
+        return;
+      }
+
+      group.translate(clientX - origin.x, clientY - origin.y);
+      origin = {
+        x: clientX,
+        y: clientY,
+      };
+    });
+
+    /* 先将 rect 完全拖离视窗，并点击画布 */
+    // 先移动到 rect 上
+    const { clientX, clientY } = getClientPoint(canvas, 100, 100);
+    simulateMouseEvent(el, 'mousemove', {
+      clientX,
+      clientY,
+    });
+    // 按下鼠标
+    simulateMouseEvent(el, 'mousedown', {
+      clientX,
+      clientY,
+    });
+    // 先移动 10 像素，触发 dragstart 事件
+    simulateMouseEvent(el, 'mousemove', {
+      clientX,
+      clientY: clientY - 10,
+    });
+    // 要模拟 drag 事件，需要触发 mousemove 事件两次及以上。因为第一次 mousemove 事件是用来触发 dragstart 事件的
+    simulateMouseEvent(el, 'mousemove', {
+      clientX,
+      clientY: clientY - 20,
+    });
+    // 将 rect 完全拖离视窗，这里通过鼠标离开画布足够距离进行模拟，拖拽距离共 200 = 210 - 10
+    simulateMouseEvent(el, 'mousemove', {
+      clientX,
+      clientY: clientY - 210,
+    });
+    // 松开鼠标，停止拖拽
+    simulateMouseEvent(el, 'mouseup', {
+      clientX,
+      clientY: clientY - 200,
+    });
+    let canvasBBox = group.getCanvasBBox();
+    // 判断 rect 是否完全拖离画布
+    expect(canvasBBox.maxY).eqls(-58);
+    // 按下鼠标
+    simulateMouseEvent(el, 'mousedown', {
+      clientX,
+      clientY,
+    });
+    simulateMouseEvent(el, 'mouseup', {
+      clientX,
+      clientY,
+    });
+    canvasBBox = group.getCanvasBBox();
+    // 判断 rect 是否移动回画布
+    expect(canvasBBox.maxY).eqls(142);
+    setTimeout(() => {
+      // stroke 判断
+      expect(getColor(context, 100 * pixelRatio, 100 * pixelRatio)).eqls('#0000ff');
+      // fill 判断
+      expect(getColor(context, (100 + 10) * pixelRatio, (100 + 10) * pixelRatio)).eqls('#ff0000');
+      done();
+    }, 25);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #494.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 [g-canvas] Fix render work incorrectly when element is clipped by view. #494          |
| 🇨🇳 Chinese | 🐞 [g-canvas] 修复当图形被视窗裁剪掉时，渲染不正常的问题。#494          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
