### PR TITLE
feat(canvas): Support context and offscreenCanvas props for non-browser env

### DIFF
--- a/__tests__/bugs/issue-556-spec.js
+++ b/__tests__/bugs/issue-556-spec.js
@@ -1,0 +1,56 @@
+const expect = require('chai').expect;
+import * as Util from '@antv/util';
+const Simulate = require('event-simulate');
+import Canvas from '../../src/canvas';
+
+const canvas = document.createElement('canvas');
+document.body.appendChild(canvas);
+const context = canvas.getContext('2d');
+
+const offscreenCanvas = Util.createDom('<canvas width="500" height="500"></canvas>');
+
+describe('#556', () => {
+  const canvas = new Canvas({
+    context,
+    offscreenCanvas,
+    width: 400,
+    height: 400,
+  });
+
+  const el = canvas.get('el');
+
+  it('canvas supports context and offscreenCanvas props for non-browser env', () => {
+    const circle = canvas.addShape('circle', {
+      attrs: {
+        x: 100,
+        y: 100,
+        r: 50,
+        fill: 'red'
+      }
+    });
+    canvas.draw();
+
+    // for renderer test
+    let clickCalled = false;
+    circle.on('click', () => {
+      clickCalled = true;
+    });
+    const bbox = el.getBoundingClientRect();
+    Simulate.simulate(el, 'click', {
+      clientY: bbox.top + 100,
+      clientX: bbox.left + 100,
+    });
+    expect(clickCalled).eqls(true);
+
+    // for interactive test
+    circle.on('mouseenter', () => {
+      circle.attr('fill', 'blue');
+      canvas.draw();
+    });
+
+    circle.on('mouseleave', () => {
+      circle.attr('fill', 'red');
+      canvas.draw();
+    });
+  });
+});

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -121,18 +121,21 @@ class Canvas extends Group {
   _setContainer() {
     const containerId = this.get('containerId');
     let containerDOM = this.get('containerDOM');
-    if (!containerDOM) {
+    if (!containerDOM && document) {
       containerDOM = document.getElementById(containerId);
       this.set('containerDOM', containerDOM);
     }
-    Util.modifyCSS(containerDOM, {
-      position: 'relative',
-    });
+    if (containerDOM) {
+      Util.modifyCSS(containerDOM, {
+        position: 'relative',
+      });
+    }
   }
 
   _initPainter() {
     const containerDOM = this.get('containerDOM');
-    const painter = new this.cfg.renderer.painter(containerDOM);
+    const context = this.get('context');
+    const painter = new this.cfg.renderer.painter(containerDOM, context);
     this.cfg.painter = painter;
     this.cfg.canvasDOM = this.cfg.el = painter.canvas;
     this.changeSize(this.get('width'), this.get('height'));

--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -58,6 +58,7 @@ abstract class Base extends EventEmitter {
     // 调用 ee 的事件 emit
     super.emit(evt, e, ...args);
 
+
     // 阻止冒泡
     if (e instanceof Event && e.propagationStopped) {
       return;

--- a/src/renderers/canvas/painter.ts
+++ b/src/renderers/canvas/painter.ts
@@ -27,9 +27,14 @@ class Painter {
   toDraw: boolean;
   animateHandler: any;
 
-  constructor(dom) {
+  constructor(dom, context) {
+    // DOM 容器不存在时，说明为非浏览器环境，此时使用上层传入的 context
     if (!dom) {
-      return null;
+      this.type = 'canvas';
+      // 从 context 中获取 canvas dom
+      this.canvas = context.canvas;
+      this.context = context;
+      return this;
     }
     const canvasId = Util.uniqueId('canvas_');
     // @ts-ignore

--- a/src/shapes/util/is-point-in-path-by-ctx.ts
+++ b/src/shapes/util/is-point-in-path-by-ctx.ts
@@ -1,10 +1,18 @@
 import * as Util from '@antv/util';
 import Shape from '../../core/shape';
 
-const canvas = Util.createDom('<canvas width="500" height="500"></canvas>');
-const context = canvas.getContext('2d');
+let offscreenCanvas;
 
-export default function isPointInPathByContext(x: number, y: number, ctx: Shape): boolean {
-  ctx.createPath(context);
+if (document) {
+  offscreenCanvas = Util.createDom('<canvas width="500" height="500"></canvas>');
+}
+
+
+export default function isPointInPathByContext(x: number, y: number, shape: Shape): boolean {
+  const canvas = shape.get('canvas');
+  // 优先使用 G 内部创建的离屏 canvas，如果不存在，则使用上层传入的离屏 canvas (通常渲染环境为小程序和 Node)
+  offscreenCanvas = offscreenCanvas || canvas.get('offscreenCanvas');
+  const context = offscreenCanvas.getContext('2d');
+  shape.createPath(context);
   return context.isPointInPath(x, y);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

- Close #556.

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

- 支持传入 `context` 以代替 `containerId` 属性配置，因为非浏览器环境无法根据 `containerId` 获取对应的容器 DOM，包括 G 内部创建 Canvas 节点的逻辑；
- `context` 上会挂载 canvas 节点对象，因此 el 可以正常获取；
- 同时还需要传入 `offscreenCanvas` 属性，因为 G 部分的拾取逻辑依赖离屏 Canvas，非浏览器环境下 G 同样无法内部创建离屏 canvas，需要外部传入。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🌟 Canvas supports `context` and `offscreenCanvas` props for non-browser env. #556          |
| 🇨🇳 Chinese | 🌟 Canvas 新增 `context` 和 `offscreenCanvas` 属性，以支持非浏览器环境 (比如小程序和 Node 端) 的渲染。#556          |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
