### PR TITLE
feat: attribute 'html' of dom shape can be a function

### DIFF
--- a/packages/g-svg/src/shape/dom.ts
+++ b/packages/g-svg/src/shape/dom.ts
@@ -20,7 +20,20 @@ class Dom extends ShapeBase {
         el.setAttribute(SVG_ATTR_MAP[attr], value);
       }
     });
-    el.innerHTML = attrs['html']; // set innerHTML
+    if (typeof attrs['html'] === 'function') {
+      const element = attrs['html'].call(this, attrs);
+      if (element instanceof Element || element instanceof HTMLDocument) {
+          const children = el.childNodes; 
+          for(let i = children.length - 1; i >= 0; i--) {
+            el.removeChild(children[i]);
+          }
+          el.appendChild(element); // append to el if it's an element
+      } else {
+          el.innerHTML = element; // set innerHTML
+      }
+    } else {
+        el.innerHTML = attrs['html']; // set innerHTML
+    }
   }
 }
 

--- a/packages/g-svg/tests/unit/shape/dom-spec.js
+++ b/packages/g-svg/tests/unit/shape/dom-spec.js
@@ -64,6 +64,37 @@ describe('SVG dom', () => {
     expect(dom.isHit(-1, -1)).eql(false);
   });
 
+  it('set html(text) by function', () => {
+    dom.attr({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      html(attrs) {
+        return `<div><h1>Hello World,${attrs.width},${attrs.height}</h1></div>`
+      }
+    });
+    expect(dom.get('el').innerHTML).eql('<div><h1>Hello World,100,100</h1></div>');
+  });
+
+  it('set html(dom) by function', () => {
+    dom.attr({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      html(attrs) {
+        const div = document.createElement('div');
+        div.id = 'new-dom-node';
+        const child = document.createElement('span');
+        child.innerHTML = `Hello Child,${attrs.width},${attrs.height}`;
+        div.appendChild(child);
+        return div;
+      }
+    });
+    expect(dom.get('el').innerHTML).eql('<div id="new-dom-node"><span>Hello Child,100,100</span></div>');
+  });
+
   it('destroy', () => {
     expect(dom.destroyed).eql(false);
     dom.destroy();


### PR DESCRIPTION
### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/antvis/G6/issues/1765

### 💡 Background and solution
Now the `html` attribute of the `dom` shape must be plain text. If the dom contains a `canvas`, it will not render correctly.
This change allows it to be a function, and the function can return text or dom elements. We can call the canvas rendering method in this function to make the canvas display correctly. Therefore, we can now customize the node with canvas-based library, such as echarts, threejs.
It should be noted that once the `draw` method of `registerNode` is overwritten, it will be called frequently, so the implementation of this function should be optimized.

![image](https://user-images.githubusercontent.com/10277628/87517998-427a2180-c6b2-11ea-926f-d2fce524b8ec.png)

![image](https://user-images.githubusercontent.com/10277628/87517631-b2d47300-c6b1-11ea-9d08-148193958c0d.png)


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
