### PR TITLE
fix(g-mobile): get globalAlpha problem in mini program

### DIFF
--- a/packages/g-mobile/src/util/mini-canvas-proxy.ts
+++ b/packages/g-mobile/src/util/mini-canvas-proxy.ts
@@ -18,6 +18,7 @@ export default class MiniCanvasProxy<T> {
         break;
       case 'globalAlpha':
         if (value || value === 0) {
+          obj['globalAlpha'] = value;
           obj['setGlobalAlpha'](value);
         }
         break;
@@ -41,8 +42,7 @@ export default class MiniCanvasProxy<T> {
   }
 
   get(obj: T, prop: string): any {
-    return (...args) => {
-      obj[prop](...args);
-    };
+    if (prop === 'globalAlpha' && obj[prop] === undefined) return 1;
+    return obj[prop];
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ √] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

none

### 💡 Background and solution

background:  opacity property of shape  didn't make effect
bug & solution:  canvas component in ant mini program  has no globalAlpha property，need to  add  in proxy。


### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix(g-mobile): get globalAlpha problem in mini program      |
| 🇨🇳 Chinese |   fix(g-mobile): 修复小程序globalAlpha问题          |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
