### PR TITLE
fix: auto transpile GLSL1.0 to 3.0 in WebGL2 context #787

### DIFF
--- a/packages/g-plugin-webgl-renderer/src/passes/CopyPass.ts
+++ b/packages/g-plugin-webgl-renderer/src/passes/CopyPass.ts
@@ -1,8 +1,6 @@
 import { inject, injectable } from 'inversify';
 import copyFrag from '../services/shader-module/shaders/webgl.copy.frag.glsl';
 import copyVert from '../services/shader-module/shaders/webgl.copy.vert.glsl';
-import copyFragWebGPU from '../services/shader-module/shaders/webgpu.copy.frag.glsl';
-import copyVertWebGPU from '../services/shader-module/shaders/webgpu.copy.vert.glsl';
 import { FrameGraphHandle } from '../components/framegraph/FrameGraphHandle';
 import { FrameGraphPass } from '../components/framegraph/FrameGraphPass';
 import { PassNode } from '../components/framegraph/PassNode';
@@ -12,6 +10,7 @@ import { gl } from '../services/renderer/constants';
 import { FrameGraphEngine, IRenderPass } from '../FrameGraphEngine';
 import { RenderPass, RenderPassData } from './RenderPass';
 import { View } from '../View';
+import { ShaderModuleService, ShaderType } from '../services/shader-module';
 
 export interface CopyPassData {
   input: FrameGraphHandle;
@@ -24,6 +23,9 @@ export class CopyPass implements IRenderPass<CopyPassData> {
 
   @inject(RenderingEngine)
   private readonly engine: RenderingEngine;
+
+  @inject(ShaderModuleService)
+  private readonly shaderModuleService: ShaderModuleService;
 
   @inject(ResourcePool)
   private readonly resourcePool: ResourcePool;
@@ -54,8 +56,8 @@ export class CopyPass implements IRenderPass<CopyPassData> {
 
     if (!this.model) {
       const model = createModel({
-        vs: this.engine.supportWebGPU ? copyVertWebGPU : copyVert,
-        fs: this.engine.supportWebGPU ? copyFragWebGPU : copyFrag,
+        vs: this.shaderModuleService.transpile(copyVert, ShaderType.Vertex, this.engine.shaderLanguage),
+        fs: this.shaderModuleService.transpile(copyFrag, ShaderType.Fragment, this.engine.shaderLanguage),
         attributes: {
           // rendering a fullscreen triangle instead of quad
           // @see https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/

--- a/packages/g-plugin-webgl-renderer/src/services/renderer/index.ts
+++ b/packages/g-plugin-webgl-renderer/src/services/renderer/index.ts
@@ -1,6 +1,7 @@
 import { Frustum } from '@antv/g';
 import { Entity } from '@antv/g-ecs';
 import { mat4, vec3 } from 'gl-matrix';
+import { TranspileTarget } from '../shader-module';
 import { gl } from './constants';
 
 export const RenderingEngine = Symbol('RenderingEngine');
@@ -615,7 +616,7 @@ export type BufferData =
 
 export interface RenderingEngine {
   supportWebGPU: boolean;
-  useWGSL: boolean;
+  shaderLanguage: TranspileTarget;
   init(cfg: IRendererConfig): void;
   clear(options: IClearOptions): void;
   createModel(options: IModelInitializationOptions): IModel;

--- a/packages/g-plugin-webgl-renderer/src/services/renderer/regl/ReglModel.ts
+++ b/packages/g-plugin-webgl-renderer/src/services/renderer/regl/ReglModel.ts
@@ -39,7 +39,6 @@ export default class ReglModel implements IModel {
     const {
       vs,
       fs,
-      defines,
       attributes,
       uniforms,
       primitive,
@@ -74,20 +73,11 @@ export default class ReglModel implements IModel {
       });
     }
 
-    const defineStmts = (defines && this.generateDefines(defines)) || '';
     const drawParams: regl.DrawConfig = {
       attributes: reglAttributes,
-      frag: `#ifdef GL_FRAGMENT_PRECISION_HIGH
-  precision highp float;
-#else
-  precision mediump float;
-#endif
-${defineStmts}
-${fs}`,
+      frag: fs,
       uniforms: reglUniforms,
-      vert: `
-${defineStmts}
-${vs}`,
+      vert: vs,
       primitive: primitiveMap[primitive === undefined ? gl.TRIANGLES : primitive],
     };
     if (instances) {
@@ -308,11 +298,5 @@ ${vs}`,
         face: cullFaceMap[face],
       };
     }
-  }
-
-  private generateDefines(defines: Record<string, number | boolean>) {
-    return Object.keys(defines)
-      .map((name) => `#define ${name} ${Number(defines[name])}`)
-      .join('\n');
   }
 }

--- a/packages/g-plugin-webgl-renderer/src/services/renderer/regl/index.ts
+++ b/packages/g-plugin-webgl-renderer/src/services/renderer/regl/index.ts
@@ -30,6 +30,7 @@ import ReglModel from './ReglModel';
 import ReglTexture2D from './ReglTexture2D';
 import { gl } from '../constants';
 import { overrideContextType } from './webgl2-compatible';
+import { TranspileTarget } from '../../shader-module';
 
 // @see https://stackoverflow.com/questions/54401577/check-if-webgl2-is-supported-and-enabled-in-clients-browser
 const isWebGL2Supported = () => !!document.createElement('canvas').getContext('webgl2');
@@ -43,6 +44,8 @@ export class WebGLEngine implements RenderingEngine {
   public useWGSL = false;
   private $canvas: HTMLCanvasElement;
   private gl: regl.Regl;
+
+  shaderLanguage: TranspileTarget = TranspileTarget.GLSL1;
 
   public init(cfg: IRendererConfig): void {
     this.$canvas = cfg.canvas!;
@@ -69,8 +72,13 @@ export class WebGLEngine implements RenderingEngine {
         optionalExtensions: ['EXT_texture_filter_anisotropic', 'EXT_blend_minmax', 'WEBGL_depth_texture'],
       });
 
-    this.gl = (cfg.disableWebGL2 || !isWebGL2Supported()) ?
-      createRegl() : overrideContextType(createRegl);
+    const useWebgl1 = cfg.disableWebGL2 || !isWebGL2Supported();
+    if (useWebgl1) {
+      this.gl = createRegl();
+    } else {
+      this.gl = overrideContextType(createRegl);
+      this.shaderLanguage = TranspileTarget.GLSL3;
+    }
   }
 
   public isFloatSupported() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#787 

### 💡 Background and solution

支持在 WebGL 环境下自动转译 GLSL 1.0 到 3.0

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
