### PR TITLE
fix: prepareForCommit返回值

### DIFF
--- a/packages/react-g/src/reconciler.ts
+++ b/packages/react-g/src/reconciler.ts
@@ -53,7 +53,7 @@ export const reconcilor = ReactReconciler<
   ): HostContext {},
 
   prepareForCommit(containerInfo: Container): Record<string, any> {
-    return {};
+    return null;
   },
   resetAfterCommit(containerInfo: Container): void {},
   preparePortalMount(containerInfo: Container): void {},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
相关issue：https://github.com/facebook/react/issues/19582
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
在react-g的reconciler实现中，在prepareForCommit中返回了`{}`，造成了应用崩溃

prepareForCommit相关文档：https://github.com/facebook/react/tree/main/packages/react-reconciler#prepareforcommitcontainerinfo
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
