### PR TITLE
chore: bump d3-interpolate

### DIFF
--- a/packages/g-base/package.json
+++ b/packages/g-base/package.json
@@ -60,7 +60,7 @@
     "@antv/util": "~2.0.13",
     "@types/d3-timer": "^2.0.0",
     "d3-ease": "^1.0.5",
-    "d3-interpolate": "^1.3.2",
+    "d3-interpolate": "^3.0.1",
     "d3-timer": "^1.0.9",
     "detect-browser": "^5.1.0",
     "tslib": "^2.0.3"


### PR DESCRIPTION
bumping d3-interpolate because old versions have a vulnerability: https://snyk.io/advisor/npm-package/d3-interpolate

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ X ] Other (about what?)
its a version bump
### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
have a look at https://github.com/antvis/G6/issues/4016 this issue I raised before

### 📝 Changelog
shouldnt really have any affect on users

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ X ] Doc is updated/provided or not needed
- [ X ] Demo is updated/provided or not needed
- [ X ] TypeScript definition is updated/provided or not needed
- [ X ] Changelog is provided or not needed
