### PR TITLE
perf: 滚动性能优化

### DIFF
--- a/packages/g-base/src/abstract/container.ts
+++ b/packages/g-base/src/abstract/container.ts
@@ -136,7 +136,7 @@ abstract class Container extends Element implements IContainer {
         (!child.isGroup() || (child.isGroup() && (child as IGroup).getChildren().length > 0))
       ) {
         hitChild = true;
-        const { minX: childMinX, maxX: childMaxX, minY: childMinY, maxY: childMaxY } = child.getBBox();
+        const { minX: childMinX, maxX: childMaxX, minY: childMinY, maxY: childMaxY } = child.getCanvasBBox();
 
         if (childMinX < minX) {
           minX = childMinX;

--- a/packages/g-base/src/abstract/container.ts
+++ b/packages/g-base/src/abstract/container.ts
@@ -77,29 +77,38 @@ abstract class Container extends Element implements IContainer {
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
-    const xArr = [];
-    const yArr = [];
+    let hitChild = false;
     // 将可见元素、图形以及不为空的图形分组筛选出来，用于包围盒合并
-    const children = this.getChildren().filter(
-      (child) =>
-        child.get('visible') && (!child.isGroup() || (child.isGroup() && (child as IGroup).getChildren().length > 0))
-    );
-    if (children.length > 0) {
-      each(children, (child: IElement) => {
-        const box = child.getBBox();
-        xArr.push(box.minX, box.maxX);
-        yArr.push(box.minY, box.maxY);
-      });
-      minX = min(xArr);
-      maxX = max(xArr);
-      minY = min(yArr);
-      maxY = max(yArr);
-    } else {
+    this.getChildren().forEach((child) => {
+      if (
+        child.get('visible') &&
+        (!child.isGroup() || (child.isGroup() && (child as IGroup).getChildren().length > 0))
+      ) {
+        hitChild = true;
+        const { minX: childMinX, maxX: childMaxX, minY: childMinY, maxY: childMaxY } = child.getBBox();
+
+        if (childMinX < minX) {
+          minX = childMinX;
+        }
+        if (childMaxX > maxX) {
+          maxX = childMaxX;
+        }
+        if (childMinY < minY) {
+          minY = childMinY;
+        }
+        if (childMaxY > maxY) {
+          maxY = childMaxY;
+        }
+      }
+    });
+
+    if (!hitChild) {
       minX = 0;
       maxX = 0;
       minY = 0;
       maxY = 0;
     }
+
     const box = {
       x: minX,
       y: minY,
@@ -119,29 +128,38 @@ abstract class Container extends Element implements IContainer {
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
-    const xArr = [];
-    const yArr = [];
+    let hitChild = false;
     // 将可见元素、图形以及不为空的图形分组筛选出来，用于包围盒合并
-    const children = this.getChildren().filter(
-      (child) =>
-        child.get('visible') && (!child.isGroup() || (child.isGroup() && (child as IGroup).getChildren().length > 0))
-    );
-    if (children.length > 0) {
-      each(children, (child: IElement) => {
-        const box = child.getCanvasBBox();
-        xArr.push(box.minX, box.maxX);
-        yArr.push(box.minY, box.maxY);
-      });
-      minX = min(xArr);
-      maxX = max(xArr);
-      minY = min(yArr);
-      maxY = max(yArr);
-    } else {
+    this.getChildren().forEach((child) => {
+      if (
+        child.get('visible') &&
+        (!child.isGroup() || (child.isGroup() && (child as IGroup).getChildren().length > 0))
+      ) {
+        hitChild = true;
+        const { minX: childMinX, maxX: childMaxX, minY: childMinY, maxY: childMaxY } = child.getBBox();
+
+        if (childMinX < minX) {
+          minX = childMinX;
+        }
+        if (childMaxX > maxX) {
+          maxX = childMaxX;
+        }
+        if (childMinY < minY) {
+          minY = childMinY;
+        }
+        if (childMaxY > maxY) {
+          maxY = childMaxY;
+        }
+      }
+    });
+
+    if (!hitChild) {
       minX = 0;
       maxX = 0;
       minY = 0;
       maxY = 0;
     }
+
     const box = {
       x: minX,
       y: minY,

--- a/packages/g-canvas/src/util/draw.ts
+++ b/packages/g-canvas/src/util/draw.ts
@@ -114,8 +114,13 @@ export function clearChanged(elements: IElement[]) {
 
 // 当某个父元素发生改变时，调用这个方法级联设置 refresh
 function setChildrenRefresh(children: IElement[], region: Region) {
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i] as IElement;
+  const len = children.length;
+  for (let i = 0; i < len; i++) {
+    const child = children[i];
+    const { cfg } = child;
+    if (!cfg.visible) {
+      continue;
+    }
     // let refresh = true;
     // 获取缓存的 bbox，如果这个 bbox 还存在则说明父元素不是矩阵发生了改变
     // const bbox = child.cfg.canvasBBox;
@@ -123,10 +128,10 @@ function setChildrenRefresh(children: IElement[], region: Region) {
     //   // 如果这时候
     //   refresh = intersectRect(bbox, region);
     // }
-    child.cfg.refresh = true;
+    cfg.refresh = true;
     // 如果需要刷新当前节点，所有的子元素设置 refresh
     if (child.isGroup()) {
-      setChildrenRefresh(child.get('children'), region);
+      setChildrenRefresh(cfg.children, region);
     }
   }
 }

--- a/packages/g-canvas/src/util/draw.ts
+++ b/packages/g-canvas/src/util/draw.ts
@@ -296,27 +296,39 @@ export function getMergedRegion(elements): Region {
   if (!elements.length) {
     return null;
   }
-  const minXArr = [];
-  const minYArr = [];
-  const maxXArr = [];
-  const maxYArr = [];
+  let mergedMinX;
+  let mergedMinY;
+  let mergedMaxX;
+  let mergedMaxY;
   each(elements, (el: IElement) => {
     const region = getRefreshRegion(el);
-    if (region) {
-      minXArr.push(region.minX);
-      minYArr.push(region.minY);
-      maxXArr.push(region.maxX);
-      maxYArr.push(region.maxY);
+
+    if (!region) {
+      return;
+    }
+
+    const { minX, minY, maxX, maxY } = region;
+
+    if (minX < mergedMinX) {
+      mergedMinX = minX;
+    }
+    if (minY < mergedMinY) {
+      mergedMinY = minY;
+    }
+    if (maxX > mergedMaxX) {
+      mergedMaxX = maxX;
+    }
+    if (maxY > mergedMaxY) {
+      mergedMaxY = maxY;
     }
   });
   return {
-    minX: min(minXArr),
-    minY: min(minYArr),
-    maxX: max(maxXArr),
-    maxY: max(maxYArr),
+    minX: mergedMinX,
+    minY: mergedMinY,
+    maxX: mergedMaxX,
+    maxY: mergedMaxY,
   };
 }
-
 export function mergeView(region, viewRegion) {
   if (!region || !viewRegion) {
     return null;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...
- [x] Performance improvement

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
#### 【背景】
我们使用g6的dagre展示依赖关系，节点数量高达**1w+**，每个节点比较复杂，包含6+个图元，所以图元总数在**6 * 1w+**;
<img width="698" alt="image" src="https://user-images.githubusercontent.com/6951527/227782997-03884d82-0a51-4f2a-b4b3-0324329dbac1.png">

#### 【遇到的困难】
当6k+节点时，滚动时开始卡顿，发现```checkRefresh```等函数耗时较长：
<img width="924" alt="image" src="https://user-images.githubusercontent.com/6951527/227782613-5a0d38bf-f052-470d-811c-6e0b7e0fc9bd.png">



#### 【分析】

1. ```checkRefresh```下的```setChildrenRefresh ```存在递归设置refresh = true，在分组及图元较多时耗时较久；
2. 继续调研代码发现，对于隐藏的element，```drawChildren ```函数是跳过渲染的，也不会再走```base.draw```重置refresh=null；
3. 所以感觉可简化下逻辑吧，对于隐藏节点没必要递归设置refresh，可节省```setChildrenRefresh ```耗时；


#### 【解决方案】
- 改造```setChildrenRefresh ``` 函数，跳过已隐藏的element；
- 配合改造逻辑，优化```@antv/g6```的```scroll-canvas```组件，在滚动时隐藏视口外的element；


#### 【收益】
6k节点下```checkRefresh```耗时
<img width="865" alt="image" src="https://user-images.githubusercontent.com/6951527/227783372-41bfd6a5-fa30-4e85-8f52-3ee41dadf2cf.png">

有个优化后的大致滚动效果[demo](https://codesandbox.io/p/github/k644606347/g6-dagre-scroll-perf/main?workspaceId=b587cdfa-f66c-4f11-8642-7939499d4f77&file=%2FREADME.md) [git](https://github.com/k644606347/g6-dagre-scroll-perf)，不过@antv/g还是旧代码，得去node_modules里的@antv/g改成新代码，如何发布改动还没搞定🧎；


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
