### PR TITLE
fix: oncancel should be triggered when calling cancel on animation #1329

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ typings/
 .idea
 
 # build
-es
+esm
 lib
 dist
 build

--- a/__tests__/unit/dom/animation.cancel.spec.ts
+++ b/__tests__/unit/dom/animation.cancel.spec.ts
@@ -1,0 +1,130 @@
+import { Canvas, Circle } from '@antv/g';
+import { Renderer as CanvasRenderer } from '@antv/g-canvas';
+import chai, { expect } from 'chai';
+// @ts-ignore
+import chaiAlmost from 'chai-almost';
+// @ts-ignore
+import sinonChai from 'sinon-chai';
+import { sleep } from '../utils';
+
+chai.use(chaiAlmost());
+chai.use(sinonChai);
+
+const $container = document.createElement('div');
+$container.id = 'container';
+document.body.prepend($container);
+
+const renderer = new CanvasRenderer();
+
+// create a canvas
+const canvas = new Canvas({
+  container: 'container',
+  width: 600,
+  height: 500,
+  renderer,
+});
+
+describe('Animation Cancel Event', () => {
+  let animation: Animation;
+
+  beforeEach(async () => {
+    const circle = new Circle({
+      id: 'circle',
+      style: {
+        fill: 'rgb(239, 244, 255)',
+        fillOpacity: 1,
+        lineWidth: 1,
+        opacity: 1,
+        r: 50,
+        stroke: 'rgb(95, 149, 255)',
+        strokeOpacity: 1,
+        cursor: 'pointer',
+      },
+    });
+    circle.setPosition(300, 200);
+
+    await canvas.ready;
+    canvas.appendChild(circle);
+
+    animation = circle.animate([], {
+      duration: 4000,
+    });
+  });
+
+  afterEach(() => {
+    canvas.destroyChildren();
+  });
+
+  afterAll(() => {
+    canvas.destroy();
+  });
+
+  it('should trigger oncancel callback correctly', async (done) => {
+    const computedTiming = animation.effect.getComputedTiming();
+
+    expect(canvas.document.timeline.currentTime).to.be.eqls(0);
+    expect(animation.currentTime).to.be.eqls(0);
+    expect(animation.playState).to.be.eqls('running');
+
+    animation.oncancel = (ev) => {
+      // According to https://w3c.github.io/csswg-drafts/web-animations-1/#canceling-an-animation-section
+      // currentTime should be null.
+      expect(ev.currentTime).to.be.eqls(null);
+      expect(animation.playState).to.be.eqls('idle');
+
+      expect(computedTiming.endTime).to.be.eqls(4000);
+      expect(computedTiming.activeDuration).to.be.eqls(4000);
+      // not running
+      expect(computedTiming.progress).to.be.eqls(null);
+      expect(computedTiming.currentIteration).to.be.eqls(null);
+
+      done();
+    };
+
+    await sleep(100);
+    animation.cancel();
+  });
+
+  it('should reject finished promise when cancelled', async (done) => {
+    // According to https://w3c.github.io/csswg-drafts/web-animations-1/#canceling-an-animation-section
+    // Reject the current finished promise.
+    animation.finished
+      .then(() => {
+        expect(true).to.be.false;
+      })
+      .catch(() => {
+        expect(true).to.be.true;
+        done();
+      });
+
+    await sleep(100);
+    animation.cancel();
+  });
+
+  it('should not trigger onfinish callback when cancelled', async (done) => {
+    animation.oncancel = (ev) => {
+      expect(true).to.be.true;
+      done();
+    };
+
+    animation.onfinish = () => {
+      expect(true).to.be.false;
+    };
+
+    await sleep(100);
+    animation.cancel();
+  });
+
+  it('oncancel must not fire when animation finishes', async (done) => {
+    animation.oncancel = (ev) => {
+      expect(true).to.be.false;
+    };
+
+    animation.onfinish = () => {
+      expect(true).to.be.true;
+      done();
+    };
+
+    await sleep(3000);
+  });
+});

--- a/demo/oom-animation.html
+++ b/demo/oom-animation.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,shrink-to-fit=no"
+    />
+    <title>OOM caused by Animations</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        height: 100%;
+      }
+
+      #container {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="container"></div>
+    <button id="add">add 100 animations</button>
+    <button id="remove all">cancel all animations</button>
+    <script
+      src="../packages/g/dist/index.umd.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../packages/g-canvas/dist/index.umd.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      const { Circle, Canvas, Group } = window.G;
+
+      // create a renderer
+      const canvasRenderer = new window.G.Canvas2D.Renderer();
+
+      // create a canvas
+      const canvas = new Canvas({
+        container: 'container',
+        width: 600,
+        height: 500,
+        renderer: canvasRenderer,
+      });
+
+      canvas.addEventListener('ready', () => {
+        let circles = [];
+        for (let i = 0; i < 1000; i++) {
+          const circle = new Circle({
+            style: {
+              cx: Math.random() * 600,
+              cy: Math.random() * 500,
+              r: 10,
+              fill: '#1890FF',
+              stroke: '#F04864',
+              lineWidth: 4,
+            },
+          });
+          circles.push(circle);
+          canvas.appendChild(circle);
+        }
+
+        let i = 0;
+        const timer = setInterval(() => {
+          if (i === 10) {
+            clearInterval(timer);
+          }
+
+          circles.forEach((circle) => {
+            circle.getAnimations().forEach((animation) => {
+              animation.cancel();
+            });
+
+            circle.animate(
+              [
+                {
+                  opacity: 0,
+                },
+                {
+                  opacity: 1,
+                },
+              ],
+              { iterations: 1, duration: 1000 },
+            );
+          });
+
+          i++;
+        }, 100);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/g-web-animations-api/src/dom/Animation.ts
+++ b/packages/g-web-animations-api/src/dom/Animation.ts
@@ -354,6 +354,23 @@ export class Animation implements IAnimation {
     this.timeline.applyDirtiedAnimation(this);
 
     this.updatePromises();
+
+    /**
+     * 1. Reject the current finished promise with a DOMException named "AbortError".
+     * 2. Let current finished promise be a new promise
+     * @see https://w3c.github.io/csswg-drafts/web-animations-1/#canceling-an-animation-section
+     */
+    if (this.finishedPromise) {
+      this.rejectFinishedPromise();
+      this.finishedPromise = undefined;
+    }
+
+    if (this.oncancel) {
+      const event = new AnimationEvent(null, this, this.currentTime, null);
+      setTimeout(() => {
+        this.oncancel(event);
+      });
+    }
   }
 
   reverse() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#1329 

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

按照 WebAnimations API 规范：https://w3c.github.io/csswg-drafts/web-animations-1/#canceling-an-animation-section
调用 `animation.cancel()` 时，需要 reject finished 这个 Promise，然后再调用 oncancel 回调。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
