### PR TITLE
fix: use pass-in runtime instead of global

### DIFF
--- a/packages/g-lite/src/css/StyleValueRegistry.ts
+++ b/packages/g-lite/src/css/StyleValueRegistry.ts
@@ -806,8 +806,7 @@ export class DefaultStyleValueRegistry implements StyleValueRegistry {
       // Marker
       // @ts-ignore
       if (attributes.markerStart) {
-        // @ts-ignore
-        object.parsedStyle.markerStart = runtime.CSSPropertySyntaxFactory[
+        object.parsedStyle.markerStart = this.runtime.CSSPropertySyntaxFactory[
           '<marker>'
         ].calculator(
           null,
@@ -821,8 +820,7 @@ export class DefaultStyleValueRegistry implements StyleValueRegistry {
       }
       // @ts-ignore
       if (attributes.markerEnd) {
-        // @ts-ignore
-        object.parsedStyle.markerEnd = runtime.CSSPropertySyntaxFactory[
+        object.parsedStyle.markerEnd = this.runtime.CSSPropertySyntaxFactory[
           '<marker>'
         ].calculator(
           null,
@@ -836,8 +834,7 @@ export class DefaultStyleValueRegistry implements StyleValueRegistry {
       }
       // @ts-ignore
       if (attributes.markerMid) {
-        // @ts-ignore
-        object.parsedStyle.markerMid = runtime.CSSPropertySyntaxFactory[
+        object.parsedStyle.markerMid = this.runtime.CSSPropertySyntaxFactory[
           '<marker>'
         ].calculator(
           '',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

`runtime` 应该使用运行时传入的变量，而非全局版本。

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
