### PR TITLE
feat: support size attenuation in annotation plugin

### DIFF
--- a/.changeset/flat-apricots-remain.md
+++ b/.changeset/flat-apricots-remain.md
@@ -1,0 +1,8 @@
+---
+'@antv/g-plugin-annotation': patch
+'@antv/g-webgpu': patch
+'@antv/g-webgl': patch
+'@antv/g-lite': patch
+---
+
+Support size attenuation.

--- a/__tests__/demos/plugin/annotation.ts
+++ b/__tests__/demos/plugin/annotation.ts
@@ -6,32 +6,15 @@ import {
   Line,
   Polyline,
   Polygon,
+  runtime,
 } from '../../../packages/g';
-import { Plugin as PluginDragndrop } from '../../../packages/g-plugin-dragndrop';
 import { Plugin as PluginAnnotation } from '../../../packages/g-plugin-annotation';
+
+let annotationPlugin;
+
+runtime.enableSizeAttenuation = true;
 export async function annotation(context) {
-  const { canvas, renderer } = context;
-
-  renderer.registerPlugin(
-    new PluginDragndrop({
-      dragstartDistanceThreshold: 10,
-      dragstartTimeThreshold: 100,
-    }),
-  );
-
-  const annotationPlugin = new PluginAnnotation({
-    enableDeleteTargetWithShortcuts: true,
-    enableAutoSwitchDrawingMode: true,
-    selectableStyle: {
-      selectionFill: 'rgba(24,144,255,0.15)',
-      selectionStroke: '#1890FF',
-      selectionStrokeWidth: 2.5,
-      anchorFill: '#1890FF',
-      anchorStroke: '#1890FF',
-    },
-  });
-
-  renderer.registerPlugin(annotationPlugin);
+  const { canvas, gui } = context;
 
   await canvas.ready;
 
@@ -70,6 +53,7 @@ export async function annotation(context) {
       // transform: 'scale(0.5) rotate(30deg)',
       // @ts-ignore
       selectable: true,
+      // transform: 'translate(100, 0)',
     },
   });
   image.addEventListener('selected', () => {
@@ -120,12 +104,31 @@ export async function annotation(context) {
     },
   });
 
+  const polygon = new Polygon({
+    style: {
+      points: [
+        [100, 100],
+        [300, 100],
+        [300, 300],
+        [100, 300],
+      ],
+      lineWidth: 10,
+      stroke: 'red',
+      // @ts-ignore
+      selectable: true,
+      // @ts-ignore
+      selectableUI: 'rect',
+      // transform: 'translate(100, 0)',
+    },
+  });
+
   canvas.appendChild(circle);
   canvas.appendChild(ellipse);
   canvas.appendChild(image);
   canvas.appendChild(rect);
   canvas.appendChild(line);
   canvas.appendChild(polyline);
+  canvas.appendChild(polygon);
 
   annotationPlugin.setDrawingMode(true);
   annotationPlugin.setDrawer('rect');
@@ -151,6 +154,7 @@ export async function annotation(context) {
         style: {
           ...brush,
           points: path.map(({ x, y }) => [x, y]),
+          isSizeAttenuation: true,
         },
       });
       canvas.appendChild(polyline);
@@ -159,17 +163,18 @@ export async function annotation(context) {
         style: {
           ...brush,
           points: path.map(({ x, y }) => [x, y]),
+          isSizeAttenuation: true,
         },
       });
       canvas.appendChild(polygon);
     } else if (type === 'rect') {
-      const rect = new Rect({
+      const rect = new Polygon({
         style: {
           ...brush,
-          x: path[0].x,
-          y: path[0].y,
-          width: path[2].x - path[0].x,
-          height: path[2].y - path[0].y,
+          // @ts-ignore
+          selectableUI: 'rect',
+          points: path.map(({ x, y }) => [x, y]),
+          isSizeAttenuation: true,
         },
       });
       canvas.appendChild(rect);
@@ -180,6 +185,8 @@ export async function annotation(context) {
           cx: path[0].x,
           cy: path[0].y,
           r: 20,
+          lineWidth: 5,
+          isSizeAttenuation: true,
         },
       });
       canvas.appendChild(circle);
@@ -189,4 +196,356 @@ export async function annotation(context) {
   annotationPlugin.addEventListener('draw:cancel', (toolstate) => {
     console.log('draw:cancel', toolstate);
   });
+
+  const selectableFolder = gui.addFolder('selectable');
+  const selectableConfig = {
+    selectionFill: 'rgba(24,144,255,0.15)',
+    selectionFillOpacity: 1,
+    selectionStroke: '#1890FF',
+    selectionStrokeOpacity: 1,
+    selectionStrokeWidth: 2.5,
+    selectionLineDash: 0,
+    anchorFill: '#1890FF',
+    anchorFillOpacity: 1,
+    anchorStroke: '#1890FF',
+    anchorStrokeOpacity: 1,
+    anchorStrokeWidth: 1,
+    anchorSize: 6,
+    selectedAnchorFill: '#1890FF',
+    allowVertexAdditionAndDeletion: true,
+    allowTargetRotation: true,
+  };
+  selectableFolder
+    .addColor(selectableConfig, 'selectionFill')
+    .onChange((selectionFill) => {
+      annotationPlugin.updateSelectableStyle({
+        selectionFill,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'selectionFillOpacity', 0, 1)
+    .onChange((selectionFillOpacity) => {
+      annotationPlugin.updateSelectableStyle({
+        selectionFillOpacity,
+      });
+    });
+  selectableFolder
+    .addColor(selectableConfig, 'selectionStroke')
+    .onChange((selectionStroke) => {
+      annotationPlugin.updateSelectableStyle({
+        selectionStroke,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'selectionStrokeOpacity', 0, 1)
+    .onChange((selectionStrokeOpacity) => {
+      annotationPlugin.updateSelectableStyle({
+        selectionStrokeOpacity,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'selectionStrokeWidth', 1, 20)
+    .onChange((selectionStrokeWidth) => {
+      annotationPlugin.updateSelectableStyle({
+        selectionStrokeWidth,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'selectionLineDash', 0, 20)
+    .onChange((selectionLineDash) => {
+      annotationPlugin.updateSelectableStyle({
+        selectionLineDash,
+      });
+    });
+  selectableFolder
+    .addColor(selectableConfig, 'anchorFill')
+    .onChange((anchorFill) => {
+      annotationPlugin.updateSelectableStyle({
+        anchorFill,
+      });
+    });
+  selectableFolder
+    .addColor(selectableConfig, 'anchorStroke')
+    .onChange((anchorStroke) => {
+      annotationPlugin.updateSelectableStyle({
+        anchorStroke,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'anchorSize', 5, 20)
+    .onChange((anchorSize) => {
+      annotationPlugin.updateSelectableStyle({
+        anchorSize,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'anchorStrokeWidth', 1, 20)
+    .onChange((anchorStrokeWidth) => {
+      annotationPlugin.updateSelectableStyle({
+        anchorStrokeWidth,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'anchorFillOpacity', 0, 1)
+    .onChange((anchorFillOpacity) => {
+      annotationPlugin.updateSelectableStyle({
+        anchorFillOpacity,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'anchorStrokeOpacity', 0, 1)
+    .onChange((anchorStrokeOpacity) => {
+      annotationPlugin.updateSelectableStyle({
+        anchorStrokeOpacity,
+      });
+    });
+  selectableFolder
+    .addColor(selectableConfig, 'selectedAnchorFill')
+    .onChange((selectedAnchorFill) => {
+      annotationPlugin.updateSelectableStyle({
+        selectedAnchorFill,
+      });
+    });
+  selectableFolder
+    .add(selectableConfig, 'allowVertexAdditionAndDeletion')
+    .onChange((allowed) => {
+      annotationPlugin.allowVertexAdditionAndDeletion(allowed);
+    });
+  selectableFolder
+    .add(selectableConfig, 'allowTargetRotation')
+    .onChange((allowed) => {
+      annotationPlugin.allowTargetRotation(allowed);
+    });
+  selectableFolder.open();
+
+  const drawerFolder = gui.addFolder('drawer');
+  const drawerConfig = {
+    rectStroke: '#FAAD14',
+    rectStrokeWidth: 2.5,
+    rectLineDash: 6,
+    polylineVertexFill: '#FFFFFF',
+    polylineVertexSize: 6,
+    polylineVertexStroke: '#FAAD14',
+    polylineVertexStrokeWidth: 2,
+    polylineActiveVertexFill: '#FAAD14',
+    polylineActiveVertexSize: 6,
+    polylineActiveVertexStroke: '#FAAD14',
+    polylineActiveVertexStrokeWidth: 4,
+    polylineSegmentStroke: '#FAAD14',
+    polylineActiveSegmentStroke: '#FAAD14',
+  };
+  drawerFolder.addColor(drawerConfig, 'rectStroke').onChange((rectStroke) => {
+    annotationPlugin.updateDrawerStyle({
+      rectStroke,
+    });
+  });
+  drawerFolder
+    .add(drawerConfig, 'rectStrokeWidth', 0, 10)
+    .onChange((rectStrokeWidth) => {
+      annotationPlugin.updateDrawerStyle({
+        rectStrokeWidth,
+      });
+    });
+  drawerFolder
+    .add(drawerConfig, 'rectLineDash', 0, 10)
+    .onChange((rectLineDash) => {
+      annotationPlugin.updateDrawerStyle({
+        rectLineDash,
+      });
+    });
+  drawerFolder
+    .addColor(drawerConfig, 'polylineVertexFill')
+    .onChange((polylineVertexFill) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineVertexFill,
+      });
+    });
+  drawerFolder
+    .addColor(drawerConfig, 'polylineVertexStroke')
+    .onChange((polylineVertexStroke) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineVertexStroke,
+      });
+    });
+  drawerFolder
+    .add(drawerConfig, 'polylineVertexSize', 0, 10)
+    .onChange((polylineVertexSize) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineVertexSize,
+      });
+    });
+  drawerFolder
+    .add(drawerConfig, 'polylineVertexStrokeWidth', 0, 10)
+    .onChange((polylineVertexStrokeWidth) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineVertexStrokeWidth,
+      });
+    });
+  drawerFolder
+    .addColor(drawerConfig, 'polylineSegmentStroke')
+    .onChange((polylineSegmentStroke) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineSegmentStroke,
+      });
+    });
+
+  drawerFolder
+    .addColor(drawerConfig, 'polylineActiveVertexFill')
+    .onChange((polylineActiveVertexFill) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineActiveVertexFill,
+      });
+    });
+  drawerFolder
+    .addColor(drawerConfig, 'polylineActiveVertexStroke')
+    .onChange((polylineActiveVertexStroke) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineActiveVertexStroke,
+      });
+    });
+  drawerFolder
+    .add(drawerConfig, 'polylineActiveVertexSize', 0, 10)
+    .onChange((polylineActiveVertexSize) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineActiveVertexSize,
+      });
+    });
+  drawerFolder
+    .add(drawerConfig, 'polylineActiveVertexStrokeWidth', 0, 10)
+    .onChange((polylineActiveVertexStrokeWidth) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineActiveVertexStrokeWidth,
+      });
+    });
+  drawerFolder
+    .addColor(drawerConfig, 'polylineActiveSegmentStroke')
+    .onChange((polylineActiveSegmentStroke) => {
+      annotationPlugin.updateDrawerStyle({
+        polylineActiveSegmentStroke,
+      });
+    });
+  drawerFolder.close();
+
+  const apiFolder = gui.addFolder('API');
+  const apiConfig = {
+    setDrawingMode: true,
+    setDrawer: 'rect',
+    selectDisplayObject: 'none',
+    deselectDisplayObject: 'none',
+    getSelectedDisplayObjects: () => {
+      console.log(annotationPlugin.getSelectedDisplayObjects());
+    },
+    removeImage: () => {
+      image.remove();
+    },
+  };
+  apiFolder.add(apiConfig, 'setDrawingMode').onChange((enable) => {
+    annotationPlugin.setDrawingMode(enable);
+  });
+  apiFolder
+    .add(apiConfig, 'setDrawer', ['rect', 'polyline', 'polygon', 'circle'])
+    .onChange((drawer) => {
+      annotationPlugin.setDrawer(drawer);
+    });
+  apiFolder
+    .add(apiConfig, 'selectDisplayObject', [
+      'rect',
+      'image',
+      'circle',
+      'ellipse',
+      'line',
+      'polyline',
+      'none',
+    ])
+    .onChange((shape) => {
+      let target;
+      if (shape === 'rect') {
+        target = rect;
+      } else if (shape === 'image') {
+        target = image;
+      } else if (shape === 'circle') {
+        target = circle;
+      } else if (shape === 'ellipse') {
+        target = ellipse;
+      } else if (shape === 'line') {
+        target = line;
+      } else if (shape === 'polyline') {
+        target = polyline;
+      }
+      annotationPlugin.selectDisplayObject(target);
+    });
+
+  apiFolder
+    .add(apiConfig, 'deselectDisplayObject', [
+      'rect',
+      'image',
+      'circle',
+      'ellipse',
+      'line',
+      'polyline',
+      'none',
+    ])
+    .onChange((shape) => {
+      let target;
+      if (shape === 'rect') {
+        target = rect;
+      } else if (shape === 'image') {
+        target = image;
+      } else if (shape === 'circle') {
+        target = circle;
+      } else if (shape === 'ellipse') {
+        target = ellipse;
+      } else if (shape === 'line') {
+        target = line;
+      } else if (shape === 'polyline') {
+        target = polyline;
+      }
+      annotationPlugin.deselectDisplayObject(target);
+    });
+
+  apiFolder.add(apiConfig, 'getSelectedDisplayObjects');
+  apiFolder.add(apiConfig, 'removeImage');
+  apiFolder.open();
+
+  const camera = canvas.getCamera();
+  const cameraFolder = gui.addFolder('camera actions');
+  const cameraConfig = {
+    panX: 0,
+    panY: 0,
+    zoom: 1,
+    roll: 0,
+  };
+  cameraFolder.add(cameraConfig, 'zoom', 0.1, 10).onChange((zoom) => {
+    camera.setZoom(zoom);
+  });
+  cameraFolder.add(cameraConfig, 'roll', -90, 90).onChange((roll) => {
+    camera.rotate(0, 0, roll);
+  });
+  cameraFolder.open();
 }
+
+annotation.initRenderer = (renderer) => {
+  annotationPlugin = new PluginAnnotation({
+    enableDeleteTargetWithShortcuts: true,
+    enableDeleteAnchorsWithShortcuts: true,
+    enableAutoSwitchDrawingMode: true,
+    enableDisplayMidAnchors: true,
+    enableSizeAttenuation: true,
+    enableRotateAnchor: true,
+    selectableStyle: {
+      selectionFill: 'rgba(24,144,255,0.15)',
+      selectionStroke: '#1890FF',
+      selectionStrokeWidth: 2.5,
+      anchorFill: '#1890FF',
+      anchorStroke: '#1890FF',
+      selectedAnchorSize: 10,
+      selectedAnchorFill: 'red',
+      selectedAnchorStroke: 'blue',
+      selectedAnchorStrokeWidth: 10,
+      selectedAnchorStrokeOpacity: 0.6,
+      midAnchorFillOpacity: 0.6,
+    },
+  });
+
+  renderer.registerPlugin(annotationPlugin);
+};

--- a/__tests__/index.html
+++ b/__tests__/index.html
@@ -4,6 +4,51 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>G: Preview</title>
+    <style>
+      .lil-gui.root {
+        position: absolute;
+        top: 0;
+        right: 0;
+        z-index: 1;
+        background: black;
+      }
+
+      .lil-gui.main li {
+        margin-left: 0 !important;
+        padding-left: 0 !important;
+        list-style-type: none !important;
+      }
+
+      .lil-gui li.title {
+        padding-left: 16px !important;
+      }
+
+      .lil-gui .c select {
+        color: black;
+      }
+
+      @keyframes animated-size {
+        0% {
+          width: 10px;
+          height: 500px;
+        }
+        50% {
+          width: 800px;
+          height: 500px;
+        }
+        100% {
+          width: 10px;
+          height: 500px;
+        }
+      }
+
+      .animatedCanvasSize {
+        animation-duration: 3s;
+        animation-iteration-count: infinite;
+        animation-name: animated-size;
+        animation-timing-function: ease;
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/packages/g-lite/src/AbstractRenderer.ts
+++ b/packages/g-lite/src/AbstractRenderer.ts
@@ -86,6 +86,7 @@ export class AbstractRenderer implements IRenderer {
        */
       enableDirtyRectangleRendering: true,
       enableDirtyRectangleRenderingDebug: false,
+      enableSizeAttenuation: true,
       ...config,
     };
   }

--- a/packages/g-lite/src/Canvas.ts
+++ b/packages/g-lite/src/Canvas.ts
@@ -20,11 +20,11 @@ import { FrustumCullingStrategy } from './plugins/FrustumCullingStrategy';
 import { PrepareRendererPlugin } from './plugins/PrepareRendererPlugin';
 import { EventService, RenderReason, RenderingService } from './services';
 import type { PointLike } from './shapes';
-import type {
-  CanvasConfig,
-  ClipSpaceNearZ,
-  Cursor,
-  InteractivePointerEvent,
+import {
+  type CanvasConfig,
+  type ClipSpaceNearZ,
+  type Cursor,
+  type InteractivePointerEvent,
 } from './types';
 import {
   caf,
@@ -293,10 +293,24 @@ export class Canvas extends EventTarget implements ICanvas {
       this.context.renderingContext.renderReasons.add(
         RenderReason.CAMERA_CHANGED,
       );
+
+      if (
+        runtime.enableSizeAttenuation &&
+        this.getConfig().renderer.getConfig().enableSizeAttenuation
+      ) {
+        this.updateSizeAttenuation();
+      }
     });
 
     // bind camera
     this.context.camera = camera;
+  }
+
+  private updateSizeAttenuation() {
+    const zoom = this.getCamera().getZoom();
+    this.document.documentElement.forEach((node: DisplayObject) => {
+      runtime.styleValueRegistry.updateSizeAttenuation(node, zoom);
+    });
   }
 
   getConfig() {

--- a/packages/g-lite/src/css/StyleValueRegistry.ts
+++ b/packages/g-lite/src/css/StyleValueRegistry.ts
@@ -1458,6 +1458,33 @@ export class DefaultStyleValueRegistry implements StyleValueRegistry {
     }
   }
 
+  updateSizeAttenuation(node: DisplayObject, zoom: number) {
+    if (node.style.isSizeAttenuation) {
+      if (!node.style.rawLineWidth) {
+        node.style.rawLineWidth = node.style.lineWidth;
+      }
+      node.style.lineWidth = node.style.rawLineWidth / zoom;
+
+      if (node.nodeName === Shape.CIRCLE) {
+        if (!node.style.rawR) {
+          node.style.rawR = node.style.r;
+        }
+        node.style.r = node.style.rawR / zoom;
+      }
+    } else {
+      if (node.style.rawLineWidth) {
+        node.style.lineWidth = node.style.rawLineWidth;
+        delete node.style.rawLineWidth;
+      }
+      if (node.nodeName === Shape.CIRCLE) {
+        if (node.style.rawR) {
+          node.style.r = node.style.rawR;
+          delete node.style.rawR;
+        }
+      }
+    }
+  }
+
   private isPropertyInheritable(name: string) {
     const metadata = propertyMetadataCache[name];
     if (!metadata) {

--- a/packages/g-lite/src/css/interfaces.ts
+++ b/packages/g-lite/src/css/interfaces.ts
@@ -136,6 +136,7 @@ export interface PropertyParseOptions {
 
 export interface StyleValueRegistry {
   recalc: (displayObject: DisplayObject) => void;
+  updateSizeAttenuation: (displayObject: DisplayObject, zoom: number) => void;
   registerMetadata: (metadata: PropertyMetadata) => void;
   unregisterMetadata: (name: string) => void;
   getPropertySyntax: (syntax: string) => CSSProperty<any, any>;

--- a/packages/g-lite/src/display-objects/Ellipse.ts
+++ b/packages/g-lite/src/display-objects/Ellipse.ts
@@ -12,6 +12,7 @@ export interface EllipseStyleProps extends BaseStyleProps {
   rx: number | string;
   ry: number | string;
   isBillboard?: boolean;
+  isSizeAttenuation?: boolean;
 }
 export interface ParsedEllipseStyleProps extends ParsedBaseStyleProps {
   cx: number;
@@ -20,6 +21,7 @@ export interface ParsedEllipseStyleProps extends ParsedBaseStyleProps {
   rx: number;
   ry: number;
   isBillboard?: boolean;
+  isSizeAttenuation?: boolean;
 }
 export class Ellipse extends DisplayObject<
   EllipseStyleProps,

--- a/packages/g-lite/src/display-objects/Polygon.ts
+++ b/packages/g-lite/src/display-objects/Polygon.ts
@@ -29,6 +29,7 @@ export interface PolygonStyleProps extends BaseStyleProps {
   markerEndOffset?: number;
   isClosed?: boolean;
   isBillboard?: boolean;
+  isSizeAttenuation?: boolean;
 }
 export interface ParsedPolygonStyleProps extends ParsedBaseStyleProps {
   points: {
@@ -43,6 +44,7 @@ export interface ParsedPolygonStyleProps extends ParsedBaseStyleProps {
   markerEndOffset?: number;
   isClosed?: boolean;
   isBillboard?: boolean;
+  isSizeAttenuation?: boolean;
 }
 
 export class Polygon extends DisplayObject<

--- a/packages/g-lite/src/display-objects/Rect.ts
+++ b/packages/g-lite/src/display-objects/Rect.ts
@@ -11,6 +11,7 @@ export interface RectStyleProps extends BaseStyleProps {
   width: number | string;
   height: number | string;
   isBillboard?: boolean;
+  isSizeAttenuation?: boolean;
   /**
    * top-left, top-right, bottom-right, bottom-left
    */
@@ -24,6 +25,7 @@ export interface ParsedRectStyleProps extends ParsedBaseStyleProps {
   width: number;
   height: number;
   isBillboard?: boolean;
+  isSizeAttenuation?: boolean;
   radius?: [number, number, number, number];
 }
 

--- a/packages/g-lite/src/global-runtime.ts
+++ b/packages/g-lite/src/global-runtime.ts
@@ -77,6 +77,8 @@ export interface GlobalRuntime {
    * circle.style.r = 100;
    */
   enableStyleSyntax: boolean;
+
+  enableSizeAttenuation: boolean;
 }
 
 /**
@@ -178,3 +180,4 @@ runtime.globalThis = getGlobalThis();
 runtime.enableCSSParsing = true;
 runtime.enableDataset = false;
 runtime.enableStyleSyntax = true;
+runtime.enableSizeAttenuation = false;

--- a/packages/g-lite/src/plugins/PrepareRendererPlugin.ts
+++ b/packages/g-lite/src/plugins/PrepareRendererPlugin.ts
@@ -54,6 +54,13 @@ export class PrepareRendererPlugin implements RenderingPlugin {
     const handleMounted = (e: FederatedEvent) => {
       const object = e.target as DisplayObject;
 
+      if (runtime.enableSizeAttenuation) {
+        runtime.styleValueRegistry.updateSizeAttenuation(
+          object,
+          canvas.getCamera().getZoom(),
+        );
+      }
+
       if (runtime.enableCSSParsing) {
         // recalc style values
         runtime.styleValueRegistry.recalc(object);

--- a/packages/g-lite/src/types.ts
+++ b/packages/g-lite/src/types.ts
@@ -362,6 +362,11 @@ export interface RendererConfig {
    */
   enableAutoRendering: boolean;
 
+  /**
+   * Canvas / SVG / Canvaskit should listen to camera changed events, while WebGL / WebGPU will apply this effect in shader.
+   */
+  enableSizeAttenuation: boolean;
+
   // plugins:
 }
 

--- a/packages/g-plugin-annotation/src/SelectablePlugin.ts
+++ b/packages/g-plugin-annotation/src/SelectablePlugin.ts
@@ -190,12 +190,11 @@ export class SelectablePlugin implements RenderingPlugin {
       }
     }
 
-    this.updateMidAnchorsVisibility(
-      this.selectableMap[object.entity] as AbstractSelectable<any>,
-    );
-    this.updateRotateAnchorVisibility(
-      this.selectableMap[object.entity] as AbstractSelectable<any>,
-    );
+    const selectable = this.selectableMap[
+      object.entity
+    ] as AbstractSelectable<any>;
+    this.updateMidAnchorsVisibility(selectable);
+    this.updateRotateAnchorVisibility(selectable);
 
     return this.selectableMap[object.entity];
   }

--- a/packages/g-plugin-annotation/src/rendering/circle-render.ts
+++ b/packages/g-plugin-annotation/src/rendering/circle-render.ts
@@ -10,6 +10,7 @@ export const renderCircle = (context: AnnotationPlugin, anno: DrawerState) => {
   if (!pointCircle) {
     pointCircle = new Circle({
       style: {
+        isSizeAttenuation: true,
         ...EDIT_POINT_STYLE,
       },
       className: anno.id,

--- a/packages/g-plugin-annotation/src/rendering/drawPoint-render.ts
+++ b/packages/g-plugin-annotation/src/rendering/drawPoint-render.ts
@@ -1,11 +1,18 @@
-import { Circle, definedProps } from '@antv/g-lite';
+import { Circle, CircleStyleProps, definedProps } from '@antv/g-lite';
 import type { AnnotationPlugin } from '../AnnotationPlugin';
-import { ACTIVE_DRAWPOINT_STYLE, NORMAL_DRAWPOINT_STYLE } from '../constants/style';
+import {
+  ACTIVE_DRAWPOINT_STYLE,
+  NORMAL_DRAWPOINT_STYLE,
+} from '../constants/style';
 import type { DrawerState } from '../interface/drawer';
 
-export const renderDrawPoints = (context: AnnotationPlugin, anno: DrawerState) => {
+export const renderDrawPoints = (
+  context: AnnotationPlugin,
+  anno: DrawerState,
+) => {
   const points = anno.path.slice(0, anno.path.length - 1);
   const length = points.length;
+  const zoom = context.canvas.getCamera().getZoom();
 
   const {
     polylineVertexFill,
@@ -28,13 +35,14 @@ export const renderDrawPoints = (context: AnnotationPlugin, anno: DrawerState) =
   }
 
   points.forEach((point, index) => {
-    const styles = index === length - 1 ? ACTIVE_DRAWPOINT_STYLE : NORMAL_DRAWPOINT_STYLE;
+    const styles =
+      index === length - 1 ? ACTIVE_DRAWPOINT_STYLE : NORMAL_DRAWPOINT_STYLE;
     const overrideStyles =
       index === length - 1
         ? {
             fill: polylineActiveVertexFill,
             fillOpacity: polylineActiveVertexFillOpacity,
-            r: polylineActiveVertexSize,
+            r: polylineActiveVertexSize as number,
             stroke: polylineActiveVertexStroke,
             strokeOpacity: polylineActiveVertexStrokeOpacity,
             strokeWidth: polylineActiveVertexStrokeWidth,
@@ -42,7 +50,7 @@ export const renderDrawPoints = (context: AnnotationPlugin, anno: DrawerState) =
         : {
             fill: polylineVertexFill,
             fillOpacity: polylineVertexFillOpacity,
-            r: polylineVertexSize,
+            r: polylineVertexSize as number,
             stroke: polylineVertexStroke,
             strokeOpacity: polylineVertexStrokeOpacity,
             strokeWidth: polylineVertexStrokeWidth,
@@ -56,6 +64,9 @@ export const renderDrawPoints = (context: AnnotationPlugin, anno: DrawerState) =
           cy: 0,
           r: 0,
           cursor: 'pointer',
+          isSizeAttenuation: true,
+          ...styles,
+          ...definedProps(overrideStyles),
         },
         className: anno.id,
         id: `${anno.id}-circle-${index}`,
@@ -75,12 +86,19 @@ export const renderDrawPoints = (context: AnnotationPlugin, anno: DrawerState) =
       // });
     }
 
-    circle.attr({
+    const circleStyle: CircleStyleProps = {
       cx: point.x,
       cy: point.y,
       visibility: 'visible',
       ...styles,
       ...definedProps(overrideStyles),
-    });
+    };
+
+    // @ts-ignore
+    circleStyle.r /= zoom;
+    // @ts-ignore
+    circleStyle.lineWidth /= zoom;
+
+    circle.attr(circleStyle);
   });
 };

--- a/packages/g-plugin-annotation/src/rendering/drawline-render.ts
+++ b/packages/g-plugin-annotation/src/rendering/drawline-render.ts
@@ -3,7 +3,10 @@ import type { AnnotationPlugin } from '../AnnotationPlugin';
 import { DRAW_LINE_STYLE } from '../constants/style';
 import type { DrawerState } from '../interface/drawer';
 
-export const renderDrawLine = (context: AnnotationPlugin, anno: DrawerState) => {
+export const renderDrawLine = (
+  context: AnnotationPlugin,
+  anno: DrawerState,
+) => {
   const drawPoints = anno.path.slice(0, anno.path.length - 1);
 
   let polyline = context.savedPolyline;
@@ -14,13 +17,17 @@ export const renderDrawLine = (context: AnnotationPlugin, anno: DrawerState) => 
     return;
   }
 
-  const { polylineSegmentStroke, polylineSegmentStrokeWidth, polylineSegmentLineDash } =
-    context.annotationPluginOptions.drawerStyle;
+  const {
+    polylineSegmentStroke,
+    polylineSegmentStrokeWidth,
+    polylineSegmentLineDash,
+  } = context.annotationPluginOptions.drawerStyle;
 
   if (!polyline) {
     polyline = new Polyline({
       style: {
         points: [],
+        isSizeAttenuation: true,
         ...DRAW_LINE_STYLE,
         ...definedProps({
           stroke: polylineSegmentStroke,

--- a/packages/g-plugin-annotation/src/rendering/polygon-render.ts
+++ b/packages/g-plugin-annotation/src/rendering/polygon-render.ts
@@ -29,6 +29,7 @@ const renderDrawingLine = (context, anno: DrawerState) => {
     polyline = new Polyline({
       style: {
         points: [],
+        isSizeAttenuation: true,
         ...DASH_LINE_STYLE,
         ...definedProps({
           stroke: polylineActiveSegmentStroke,

--- a/packages/g-plugin-annotation/src/rendering/polyline-render.ts
+++ b/packages/g-plugin-annotation/src/rendering/polyline-render.ts
@@ -7,7 +7,9 @@ import { renderDrawPoints } from './drawPoint-render';
 
 const renderDrawingLine = (context: AnnotationPlugin, anno: DrawerState) => {
   const total = anno.path.length;
-  const drawingPoints = [anno.path[total - 2], anno.path[total - 1]].filter((point) => !!point);
+  const drawingPoints = [anno.path[total - 2], anno.path[total - 1]].filter(
+    (point) => !!point,
+  );
 
   let polyline = context.polylineLastSegment;
   if (drawingPoints.length < 2) {
@@ -27,6 +29,7 @@ const renderDrawingLine = (context: AnnotationPlugin, anno: DrawerState) => {
     polyline = new Polyline({
       style: {
         points: [],
+        isSizeAttenuation: true,
         ...DASH_LINE_STYLE,
         ...definedProps({
           stroke: polylineActiveSegmentStroke,
@@ -46,7 +49,10 @@ const renderDrawingLine = (context: AnnotationPlugin, anno: DrawerState) => {
     visibility: 'visible',
   });
 };
-export const renderPolyline = (context: AnnotationPlugin, anno: DrawerState) => {
+export const renderPolyline = (
+  context: AnnotationPlugin,
+  anno: DrawerState,
+) => {
   renderDrawPoints(context, anno);
   renderDrawLine(context, anno);
   renderDrawingLine(context, anno);

--- a/packages/g-plugin-annotation/src/rendering/rect-render.ts
+++ b/packages/g-plugin-annotation/src/rendering/rect-render.ts
@@ -1,4 +1,4 @@
-import type { PointLike } from '@antv/g-lite';
+import type { PointLike, PolygonStyleProps } from '@antv/g-lite';
 import { Polygon, definedProps } from '@antv/g-lite';
 import type { AnnotationPlugin } from '../AnnotationPlugin';
 import { DASH_LINE_STYLE, DEFAULT_STYLE } from '../constants/style';
@@ -46,7 +46,7 @@ export const renderRect = (context: AnnotationPlugin, anno: DrawerState) => {
     context.brushRect = brushRect;
   }
 
-  brushRect.attr({
+  const rectStyle: PolygonStyleProps = {
     points: [
       [tl.x, tl.y],
       [tr.x, tr.y],
@@ -60,8 +60,14 @@ export const renderRect = (context: AnnotationPlugin, anno: DrawerState) => {
       fillOpacity: rectFillOpacity,
       stroke: rectStroke,
       strokeOpacity: rectStrokeOpacity,
-      strokeWidth: rectStrokeWidth,
+      lineWidth: rectStrokeWidth,
       lineDash: rectLineDash,
     }),
-  });
+  };
+
+  const zoom = context.canvas.getCamera().getZoom();
+  // @ts-ignore
+  rectStyle.lineWidth /= zoom;
+
+  brushRect.attr(rectStyle);
 };

--- a/packages/g-plugin-annotation/src/selectable/SelectableCircle.ts
+++ b/packages/g-plugin-annotation/src/selectable/SelectableCircle.ts
@@ -18,27 +18,27 @@ export class SelectableCircle extends AbstractSelectable<Circle> {
     } = this.style;
 
     const { cx, cy, r } = target.parsedStyle;
+    const zoom = this.ownerDocument.defaultView.getCamera().getZoom();
 
     this.mask = new Circle({
       style: {
         cx,
         cy,
-        r,
+        r: r * zoom,
         draggable: target.style.maskDraggable === false ? false : true,
         increasedLineWidthForHitTesting:
           this.plugin.annotationPluginOptions.selectableStyle
             .maskIncreasedLineWidthForHitTesting,
         cursor: 'move',
+        isSizeAttenuation: true,
+        lineWidth: selectionStrokeWidth,
+        fill: selectionFill,
+        stroke: selectionStroke,
+        fillOpacity: selectionFillOpacity,
+        strokeOpacity: selectionStrokeOpacity,
       },
     });
     this.appendChild(this.mask);
-
-    // resize according to target
-    this.mask.style.fill = selectionFill;
-    this.mask.style.stroke = selectionStroke;
-    this.mask.style.fillOpacity = selectionFillOpacity;
-    this.mask.style.strokeOpacity = selectionStrokeOpacity;
-    this.mask.style.lineWidth = selectionStrokeWidth;
 
     this.bindEventListeners();
   }

--- a/packages/g-plugin-annotation/src/selectable/SelectableImage.ts
+++ b/packages/g-plugin-annotation/src/selectable/SelectableImage.ts
@@ -65,6 +65,13 @@ export class SelectableImage extends AbstractSelectable<Rect> {
         height: 0,
         draggable: target.style.maskDraggable === false ? false : true,
         cursor: 'move',
+        isSizeAttenuation: true,
+        fill: selectionFill,
+        stroke: selectionStroke,
+        fillOpacity: selectionFillOpacity,
+        strokeOpacity: selectionStrokeOpacity,
+        lineWidth: selectionStrokeWidth,
+        lineDash: selectionLineDash,
       },
     });
     this.image = target.cloneNode();
@@ -81,9 +88,15 @@ export class SelectableImage extends AbstractSelectable<Rect> {
 
     this.tlAnchor = new Circle({
       style: {
-        r: 10,
+        r: anchorSize,
         cursor: 'nwse-resize',
         draggable: true,
+        isSizeAttenuation: true,
+        stroke: anchorStroke,
+        fill: anchorFill,
+        fillOpacity: anchorFillOpacity,
+        strokeOpacity: anchorStrokeOpacity,
+        strokeWidth: anchorStrokeWidth,
       },
     });
 
@@ -116,13 +129,6 @@ export class SelectableImage extends AbstractSelectable<Rect> {
     // resize according to target
     this.mask.style.width = width;
     this.mask.style.height = height;
-    this.mask.style.fill = selectionFill;
-    this.mask.style.stroke = selectionStroke;
-    this.mask.style.fillOpacity = selectionFillOpacity;
-    this.mask.style.strokeOpacity = selectionStrokeOpacity;
-    this.mask.style.lineWidth = selectionStrokeWidth;
-    this.mask.style.lineDash = selectionLineDash;
-
     this.image.style.width = width;
     this.image.style.height = height;
 
@@ -136,13 +142,6 @@ export class SelectableImage extends AbstractSelectable<Rect> {
       if (target.style.anchorsVisibility === 'hidden') {
         anchor.style.visibility = 'hidden';
       }
-
-      anchor.style.stroke = anchorStroke;
-      anchor.style.fill = anchorFill;
-      anchor.style.fillOpacity = anchorFillOpacity;
-      anchor.style.strokeOpacity = anchorStrokeOpacity;
-      anchor.style.strokeWidth = anchorStrokeWidth;
-      anchor.style.r = anchorSize;
       anchor.style.cursor = this.scaleCursorStyleHandler(
         controls[i],
         target,

--- a/packages/g-plugin-annotation/src/selectable/SelectablePolygon.ts
+++ b/packages/g-plugin-annotation/src/selectable/SelectablePolygon.ts
@@ -30,6 +30,12 @@ export class SelectablePolygon extends AbstractSelectable<Polygon> {
           this.plugin.annotationPluginOptions.selectableStyle
             .maskIncreasedLineWidthForHitTesting,
         cursor: 'move',
+        isSizeAttenuation: true,
+        fill: selectionFill,
+        stroke: selectionStroke,
+        fillOpacity: selectionFillOpacity,
+        strokeOpacity: selectionStrokeOpacity,
+        lineWidth: selectionStrokeWidth,
       },
     });
     this.appendChild(this.mask);
@@ -40,13 +46,6 @@ export class SelectablePolygon extends AbstractSelectable<Polygon> {
     });
 
     this.repositionAnchors();
-
-    // resize according to target
-    this.mask.style.fill = selectionFill;
-    this.mask.style.stroke = selectionStroke;
-    this.mask.style.fillOpacity = selectionFillOpacity;
-    this.mask.style.strokeOpacity = selectionStrokeOpacity;
-    this.mask.style.lineWidth = selectionStrokeWidth;
 
     this.bindEventListeners();
   }
@@ -74,6 +73,7 @@ export class SelectablePolygon extends AbstractSelectable<Polygon> {
         draggable: true,
         visibility:
           target.style.anchorsVisibility === 'hidden' ? 'hidden' : 'unset',
+        isSizeAttenuation: true,
       },
     });
     this.anchors.push(anchor);
@@ -116,6 +116,7 @@ export class SelectablePolygon extends AbstractSelectable<Polygon> {
         draggable: true,
         visibility:
           target.style.anchorsVisibility === 'hidden' ? 'hidden' : 'unset',
+        isSizeAttenuation: true,
       },
     });
     this.midAnchors.push(midAnchor);

--- a/packages/g-plugin-annotation/src/selectable/SelectablePolyline.ts
+++ b/packages/g-plugin-annotation/src/selectable/SelectablePolyline.ts
@@ -37,6 +37,12 @@ export class SelectablePolyline extends AbstractSelectable<Polyline> {
           this.plugin.annotationPluginOptions.selectableStyle
             .maskIncreasedLineWidthForHitTesting,
         cursor: 'move',
+        isSizeAttenuation: true,
+        fill: selectionFill,
+        stroke: selectionStroke,
+        fillOpacity: selectionFillOpacity,
+        strokeOpacity: selectionStrokeOpacity,
+        lineWidth: selectionStrokeWidth,
       },
     });
     this.appendChild(this.mask);
@@ -52,13 +58,6 @@ export class SelectablePolyline extends AbstractSelectable<Polyline> {
     });
 
     this.repositionAnchors();
-
-    // resize according to target
-    this.mask.style.fill = selectionFill;
-    this.mask.style.stroke = selectionStroke;
-    this.mask.style.fillOpacity = selectionFillOpacity;
-    this.mask.style.strokeOpacity = selectionStrokeOpacity;
-    this.mask.style.lineWidth = selectionStrokeWidth;
 
     this.bindEventListeners();
   }
@@ -86,6 +85,7 @@ export class SelectablePolyline extends AbstractSelectable<Polyline> {
         draggable: true,
         visibility:
           target.style.anchorsVisibility === 'hidden' ? 'hidden' : 'unset',
+        isSizeAttenuation: true,
       },
     });
     this.anchors.push(anchor);
@@ -128,6 +128,7 @@ export class SelectablePolyline extends AbstractSelectable<Polyline> {
         draggable: true,
         visibility:
           target.style.anchorsVisibility === 'hidden' ? 'hidden' : 'unset',
+        isSizeAttenuation: true,
       },
     });
     this.midAnchors.push(midAnchor);
@@ -279,6 +280,8 @@ export class SelectablePolyline extends AbstractSelectable<Polyline> {
           e.canvasY,
         ]);
         this.mask.style.points = originPoints;
+
+        this.plugin.getOrCreateSelectableUI(this.style.target);
       }
     });
     this.addEventListener('drag', (e: FederatedEvent) => {

--- a/packages/g-plugin-annotation/src/selectable/SelectableRect.ts
+++ b/packages/g-plugin-annotation/src/selectable/SelectableRect.ts
@@ -63,6 +63,13 @@ export class SelectableRect extends AbstractSelectable<Rect> {
         height: 0,
         draggable: target.style.maskDraggable === false ? false : true,
         cursor: 'move',
+        isSizeAttenuation: true,
+        fill: selectionFill,
+        stroke: selectionStroke,
+        fillOpacity: selectionFillOpacity,
+        strokeOpacity: selectionStrokeOpacity,
+        lineWidth: selectionStrokeWidth,
+        lineDash: selectionLineDash,
       },
     });
 
@@ -70,9 +77,15 @@ export class SelectableRect extends AbstractSelectable<Rect> {
 
     this.tlAnchor = new Circle({
       style: {
-        r: 10,
+        r: anchorSize,
         cursor: 'nwse-resize',
         draggable: true,
+        isSizeAttenuation: true,
+        stroke: anchorStroke,
+        fill: anchorFill,
+        fillOpacity: anchorFillOpacity,
+        strokeOpacity: anchorStrokeOpacity,
+        lineWidth: anchorStrokeWidth,
       },
     });
 
@@ -105,12 +118,6 @@ export class SelectableRect extends AbstractSelectable<Rect> {
     // resize according to target
     this.mask.style.width = width;
     this.mask.style.height = height;
-    this.mask.style.fill = selectionFill;
-    this.mask.style.stroke = selectionStroke;
-    this.mask.style.fillOpacity = selectionFillOpacity;
-    this.mask.style.strokeOpacity = selectionStrokeOpacity;
-    this.mask.style.lineWidth = selectionStrokeWidth;
-    this.mask.style.lineDash = selectionLineDash;
 
     // position anchors
     this.trAnchor.setLocalPosition(width, 0);
@@ -122,13 +129,6 @@ export class SelectableRect extends AbstractSelectable<Rect> {
       if (target.style.anchorsVisibility === 'hidden') {
         anchor.style.visibility = 'hidden';
       }
-
-      anchor.style.stroke = anchorStroke;
-      anchor.style.fill = anchorFill;
-      anchor.style.fillOpacity = anchorFillOpacity;
-      anchor.style.strokeOpacity = anchorStrokeOpacity;
-      anchor.style.strokeWidth = anchorStrokeWidth;
-      anchor.style.r = anchorSize;
       anchor.style.cursor = this.scaleCursorStyleHandler(
         controls[i],
         target,

--- a/packages/g-plugin-annotation/src/selectable/SelectableRectPolygon.ts
+++ b/packages/g-plugin-annotation/src/selectable/SelectableRectPolygon.ts
@@ -69,15 +69,24 @@ export class SelectableRectPolygon extends AbstractSelectable<Polygon> {
         points,
         draggable: target.style.maskDraggable === false ? false : true,
         cursor: 'move',
+        isSizeAttenuation: true,
+        fill: selectionFill,
+        stroke: selectionStroke,
+        fillOpacity: selectionFillOpacity,
+        strokeOpacity: selectionStrokeOpacity,
+        lineWidth: selectionStrokeWidth,
+        lineDash: selectionLineDash,
       },
     });
     this.appendChild(this.mask);
 
     this.tlAnchor = new Circle({
       style: {
-        r: 10,
+        r: anchorSize,
         cursor: 'nwse-resize',
         draggable: true,
+        isSizeAttenuation: true,
+        lineWidth: anchorStrokeWidth,
       },
     });
 
@@ -98,14 +107,6 @@ export class SelectableRectPolygon extends AbstractSelectable<Polygon> {
     this.mask.appendChild(this.brAnchor);
     this.mask.appendChild(this.blAnchor);
 
-    // resize according to target
-    this.mask.style.fill = selectionFill;
-    this.mask.style.stroke = selectionStroke;
-    this.mask.style.fillOpacity = selectionFillOpacity;
-    this.mask.style.strokeOpacity = selectionStrokeOpacity;
-    this.mask.style.lineWidth = selectionStrokeWidth;
-    this.mask.style.lineDash = selectionLineDash;
-
     // set anchors' style
     this.anchors.forEach((anchor, i) => {
       if (target.style.anchorsVisibility === 'hidden') {
@@ -116,8 +117,6 @@ export class SelectableRectPolygon extends AbstractSelectable<Polygon> {
       anchor.style.fill = anchorFill;
       anchor.style.fillOpacity = anchorFillOpacity;
       anchor.style.strokeOpacity = anchorStrokeOpacity;
-      anchor.style.strokeWidth = anchorStrokeWidth;
-      anchor.style.r = anchorSize;
       anchor.style.cursor = this.scaleCursorStyleHandler(
         controls[i],
         target,
@@ -147,6 +146,7 @@ export class SelectableRectPolygon extends AbstractSelectable<Polygon> {
           draggable: true,
           visibility:
             target.style.anchorsVisibility === 'hidden' ? 'hidden' : 'unset',
+          isSizeAttenuation: true,
         },
       });
       this.mask.appendChild(this.rotateAnchor);

--- a/packages/g-webgl/src/index.ts
+++ b/packages/g-webgl/src/index.ts
@@ -18,7 +18,10 @@ export interface WebGLRendererConfig extends RendererConfig {
 
 export class Renderer extends AbstractRenderer {
   constructor(config?: Partial<WebGLRendererConfig>) {
-    super(config);
+    super({
+      enableSizeAttenuation: false,
+      ...config,
+    });
 
     const deviceRendererPlugin = new DeviceRenderer.Plugin(config);
 

--- a/packages/g-webgpu/src/index.ts
+++ b/packages/g-webgpu/src/index.ts
@@ -16,7 +16,10 @@ export class Renderer extends AbstractRenderer {
   clipSpaceNearZ = ClipSpaceNearZ.ZERO;
 
   constructor(config?: Partial<WebGPURendererConfig>) {
-    super(config);
+    super({
+      enableSizeAttenuation: false,
+      ...config,
+    });
 
     const deviceRendererPlugin = new DeviceRenderer.Plugin();
     this.registerPlugin(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

When using `@antv/g-plugin-annotation`, we want the anchors & lineWidth of selectable UI to keep the fixed size, which means camera's zooming won't affect them.

It's quite similar to [sizeAttenuation](https://threejs.org/docs/#api/en/materials/SpriteMaterial.sizeAttenuation) in Three.js.

![Feb-23-2024 13-29-02](https://github.com/antvis/G/assets/3608471/27971393-e42c-4025-8f2d-7335865e8351)


### 💡 Background and solution

Enabling `enableSizeAttenuation` will affect the selectable UI during initialization. When using drawer

```ts
import { runtime } from '@antv/g';

// Now canvas will listen to camera's changed event and modify each shape's `lineWidth` or `size` with `isSizeAttenuation` enabled.
runtime.enableSizeAttenuation = true;

const circle = new Circle({
  style: {
    r: 10,
    isSizeAttenuation: true, // Enable this option when created.
  }
});
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
