### PR TITLE
fix(g-base): container类卸载后再去调用getChildren报错

### DIFF
--- a/packages/g-base/src/abstract/container.ts
+++ b/packages/g-base/src/abstract/container.ts
@@ -318,7 +318,7 @@ abstract class Container extends Element implements IContainer {
   }
 
   getChildren(): IElement[] {
-    return this.get('children') as IElement[];
+    return (this.get('children') || []) as IElement[];
   }
 
   sort() {


### PR DESCRIPTION
  PR includes
   ant-charts 双轴图 在 geometryOptions ==>> label ==>>  layout配置中启用 limit-in-plot报错
   
![image](https://github.com/antvis/G/assets/80903923/e6d23be1-5743-4b2b-aa65-8a9132937e57)
