### PR TITLE
fix: clippath's bounds should be copied before intersection #1636

### DIFF
--- a/.changeset/lazy-mayflies-sleep.md
+++ b/.changeset/lazy-mayflies-sleep.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+ClipPath should be copied first before calculate intersection bounds.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
-      - name: Install Playwright deps
-        run: pnpm exec playwright install
-
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: pnpm exec playwright install
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
           node-version: 16
           cache: 'pnpm'
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
       - name: Install dependencies
         run: pnpm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright deps
         run: pnpm exec playwright install
 
       - name: Install dependencies

--- a/__tests__/demos/bugfix/1636.ts
+++ b/__tests__/demos/bugfix/1636.ts
@@ -1,0 +1,48 @@
+import { Image, Group, Rect } from '../../../packages/g';
+
+export async function image(context) {
+  const { canvas } = context;
+  await canvas.ready;
+
+  const rect = new Rect({
+    style: {
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 600,
+    },
+  });
+  const group = new Group({
+    style: {
+      clipPath: rect,
+    },
+  });
+  canvas.appendChild(group);
+
+  const img = new window.Image();
+  img.onload = () => {
+    const image = new Image({
+      style: {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        img,
+      },
+    });
+    const image2 = new Image({
+      style: {
+        x: 50,
+        y: 0,
+        width: 100,
+        height: 100,
+        img,
+      },
+    });
+    group.appendChild(image);
+    group.appendChild(image2);
+  };
+  img.src =
+    'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*_aqoS73Se3sAAAAAAAAAAAAAARQnAQ';
+  img.crossOrigin = 'anonymous';
+}

--- a/__tests__/demos/bugfix/index.ts
+++ b/__tests__/demos/bugfix/index.ts
@@ -1,1 +1,2 @@
 export { html } from './1610';
+export { image } from './1636';

--- a/__tests__/main.ts
+++ b/__tests__/main.ts
@@ -1,5 +1,5 @@
 import * as lil from 'lil-gui';
-import { Canvas, CanvasEvent } from '../packages/g';
+import { runtime, Canvas, CanvasEvent } from '../packages/g';
 import { Renderer as CanvasRenderer } from '../packages/g-canvas';
 import { Renderer as CanvaskitRenderer } from '../packages/g-canvaskit';
 import { Renderer as SVGRenderer } from '../packages/g-svg';
@@ -15,6 +15,8 @@ import * as plugin from './demos/plugin';
 import * as hammerjs from './demos/hammerjs';
 import * as lottie from './demos/lottie';
 import * as bugfix from './demos/bugfix';
+
+runtime.enableCSSParsing = false;
 
 const tests = {
   ...createSpecRender(namespace(basic2d, '2d')),

--- a/__tests__/unit/abstract-renderer.spec.ts
+++ b/__tests__/unit/abstract-renderer.spec.ts
@@ -10,6 +10,7 @@ describe('Abstract renderer', () => {
       enableCulling: false,
       enableDirtyRectangleRendering: true,
       enableDirtyRectangleRenderingDebug: false,
+      enableSizeAttenuation: true,
     });
 
     renderer.setConfig({ enableAutoRendering: false });
@@ -19,6 +20,7 @@ describe('Abstract renderer', () => {
       enableCulling: false,
       enableDirtyRectangleRendering: true,
       enableDirtyRectangleRenderingDebug: false,
+      enableSizeAttenuation: true,
     });
 
     expect(renderer.getPlugins().length).toBe(0);

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,7 +42,7 @@ module.exports = {
     '<rootDir>/__tests__/unit/*.spec.+(ts|tsx|js)',
   ],
   testPathIgnorePatterns: process.env.CI
-    ? ['<rootDir>/__tests__/unit/g-gesture']
+    ? ['<rootDir>/__tests__/unit/g-gesture', '<rootDir>/__tests__/main.ts']
     : ['<rootDir>/__tests__/unit/g-gesture'],
   preset: 'ts-jest',
   transform: {

--- a/packages/g-lite/src/services/SceneGraphService.ts
+++ b/packages/g-lite/src/services/SceneGraphService.ts
@@ -849,6 +849,10 @@ export class DefaultSceneGraphService implements SceneGraphService {
       }
     });
 
+    if (!aabb) {
+      aabb = new AABB();
+    }
+
     if (render) {
       // FIXME: account for clip path
       const clipped = findClosestClipPathTarget(element as DisplayObject);
@@ -856,28 +860,18 @@ export class DefaultSceneGraphService implements SceneGraphService {
         // use bounds under world space
         const clipPathBounds = clipped.parsedStyle.clipPath.getBounds(render);
         if (!aabb) {
-          aabb = clipPathBounds;
+          aabb.update(clipPathBounds.center, clipPathBounds.halfExtents);
         } else if (clipPathBounds) {
           aabb = clipPathBounds.intersection(aabb);
         }
       }
     }
 
-    if (!aabb) {
-      aabb = new AABB();
-    }
-
-    if (aabb) {
-      if (render) {
-        renderable.renderBounds = aabb;
-      } else {
-        renderable.bounds = aabb;
-      }
-    }
-
     if (render) {
+      renderable.renderBounds = aabb;
       renderable.renderBoundsDirty = false;
     } else {
+      renderable.bounds = aabb;
       renderable.boundsDirty = false;
     }
 

--- a/packages/g-lite/src/services/aabb/RectUpdater.ts
+++ b/packages/g-lite/src/services/aabb/RectUpdater.ts
@@ -1,5 +1,10 @@
 import { isString } from '@antv/util';
-import type { Group, Image, ParsedImageStyleProps, Rect } from '../../display-objects';
+import type {
+  Group,
+  Image,
+  ParsedImageStyleProps,
+  Rect,
+} from '../../display-objects';
 import type { GeometryAABBUpdater } from './interfaces';
 export class RectUpdater implements GeometryAABBUpdater<ParsedImageStyleProps> {
   update(parsedStyle: ParsedImageStyleProps, object: Image | Rect | Group) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

#1636 

The bound of `clipPath` should be copied before doing calculation intersection.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
