### PR TITLE
fix: support cameras array

### DIFF
--- a/.changeset/blue-ants-decide.md
+++ b/.changeset/blue-ants-decide.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-plugin-device-renderer': patch
+---
+
+Support multiple viewport.

--- a/__tests__/demos/3d/force.ts
+++ b/__tests__/demos/3d/force.ts
@@ -1642,6 +1642,7 @@ export async function force(context) {
   const material = new MeshPhongMaterial(device, {
     shininess: 30,
   });
+  // material.polygonOffset = true;
 
   // @see https://antv.vision/en/docs/specification/language/palette#%E5%88%86%E7%B1%BB%E8%89%B2%E6%9D%BF
   const colorPalette = [
@@ -1683,78 +1684,78 @@ export async function force(context) {
       sphere.style.fill = fill;
     });
 
-    const icon = new Image({
-      style: {
-        x: node.x + 310,
-        y: node.y + 250,
-        z: node.z - 1,
-        width: 10,
-        height: 10,
-        src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',
-        isBillboard: true,
-      },
-    });
-    canvas.appendChild(icon);
+    // const icon = new Image({
+    //   style: {
+    //     x: node.x + 310,
+    //     y: node.y + 250,
+    //     z: node.z - 1,
+    //     width: 10,
+    //     height: 10,
+    //     src: 'https://gw.alipayobjects.com/mdn/rms_6ae20b/afts/img/A*N4ZMS7gHsUIAAAAAAAAAAABkARQnAQ',
+    //     isBillboard: true,
+    //   },
+    // });
+    // canvas.appendChild(icon);
 
-    const circle = new Circle({
-      style: {
-        cx: node.x + 310,
-        cy: node.y + 250,
-        cz: node.z - 2,
-        r: 2.5,
-        fill: 'red',
-        isBillboard: true,
-      },
-    });
-    canvas.appendChild(circle);
+    // const circle = new Circle({
+    //   style: {
+    //     cx: node.x + 310,
+    //     cy: node.y + 250,
+    //     cz: node.z - 2,
+    //     r: 2.5,
+    //     fill: 'red',
+    //     isBillboard: true,
+    //   },
+    // });
+    // canvas.appendChild(circle);
 
-    const label = new Text({
-      style: {
-        x: node.x + 310,
-        y: node.y + 250,
-        z: node.z + 1,
-        fontFamily: 'sans-serif',
-        text: node.id,
-        fontSize: 6,
-        fill: 'black',
-        isBillboard: true,
-      },
-    });
+    // const label = new Text({
+    //   style: {
+    //     x: node.x + 310,
+    //     y: node.y + 250,
+    //     z: node.z + 1,
+    //     fontFamily: 'sans-serif',
+    //     text: node.id,
+    //     fontSize: 6,
+    //     fill: 'black',
+    //     isBillboard: true,
+    //   },
+    // });
 
-    const rect = new Rect({
-      style: {
-        x: node.x + 310,
-        y: node.y + 250,
-        z: node.z,
-        width: label.getBBox().width,
-        height: 8,
-        fill: 'grey',
-        isBillboard: true,
-        fillOpacity: 0.6,
-      },
-    });
-    canvas.appendChild(rect);
-    canvas.appendChild(label);
+    // const rect = new Rect({
+    //   style: {
+    //     x: node.x + 310,
+    //     y: node.y + 250,
+    //     z: node.z,
+    //     width: label.getBBox().width,
+    //     height: 8,
+    //     fill: 'grey',
+    //     isBillboard: true,
+    //     fillOpacity: 0.6,
+    //   },
+    // });
+    // canvas.appendChild(rect);
+    // canvas.appendChild(label);
   });
 
-  dataset.links.forEach((edge) => {
-    const { source, target } = edge;
-    const line = new Line({
-      style: {
-        x1: source.x + 300,
-        y1: source.y + 250,
-        z1: source.z,
-        x2: target.x + 300,
-        y2: target.y + 250,
-        z2: target.z,
-        stroke: 'black',
-        lineWidth: 2,
-        opacity: 0.5,
-        isBillboard: true, // 始终面向屏幕
-      },
-    });
-    canvas.appendChild(line);
-  });
+  // dataset.links.forEach((edge) => {
+  //   const { source, target } = edge;
+  //   const line = new Line({
+  //     style: {
+  //       x1: source.x + 300,
+  //       y1: source.y + 250,
+  //       z1: source.z,
+  //       x2: target.x + 300,
+  //       y2: target.y + 250,
+  //       z2: target.z,
+  //       stroke: 'black',
+  //       lineWidth: 2,
+  //       opacity: 0.5,
+  //       isBillboard: true, // 始终面向屏幕
+  //     },
+  //   });
+  //   canvas.appendChild(line);
+  // });
 
   // add a directional light into scene
   const light = new DirectionalLight({

--- a/__tests__/demos/3d/webar.ts
+++ b/__tests__/demos/3d/webar.ts
@@ -49,12 +49,14 @@ export async function ar(context) {
   });
 
   // cube.setOrigin(300, 250, 200);
-  cube.setPosition(300, 250, 200);
+  cube.setPosition(300, 250, -200);
 
   canvas.appendChild(cube);
 
+  // Called every time a XRSession requests that a new frame be drawn.
+  // @see https://github.com/immersive-web/webxr-samples/blob/main/immersive-ar-session.html#L173
   canvas.addEventListener(CanvasEvent.AFTER_RENDER, () => {
-    cube.rotate(0, 0, 0);
+    cube.rotate(0, 0.2, 0);
   });
 
   canvas.getConfig().disableHitTesting = true;

--- a/__tests__/main.ts
+++ b/__tests__/main.ts
@@ -191,7 +191,7 @@ function createSpecRender(object) {
         shaderCompilerPath: '/glsl_wgsl_compiler_bg.wasm',
         // enableAutoRendering: false,
         // enableDirtyRectangleRendering: false,
-        enableDirtyRectangleRenderingDebug: true,
+        // enableDirtyRectangleRenderingDebug: true,
       });
 
       if (generate.initRenderer) {

--- a/__tests__/main.ts
+++ b/__tests__/main.ts
@@ -191,7 +191,7 @@ function createSpecRender(object) {
         shaderCompilerPath: '/glsl_wgsl_compiler_bg.wasm',
         // enableAutoRendering: false,
         // enableDirtyRectangleRendering: false,
-        // enableDirtyRectangleRenderingDebug: true,
+        enableDirtyRectangleRenderingDebug: true,
       });
 
       if (generate.initRenderer) {
@@ -218,31 +218,6 @@ function createSpecRender(object) {
       $div.appendChild(gui.domElement);
 
       await generate({ canvas, renderer, container: $div, gui });
-
-      if (
-        selectRenderer.value === 'canvas' &&
-        renderer.getConfig().enableDirtyRectangleRendering &&
-        renderer.getConfig().enableDirtyRectangleRenderingDebug
-      ) {
-        // display dirty rectangle
-        const $dirtyRectangle = document.createElement('div');
-        $dirtyRectangle.style.cssText = `
-        position: absolute;
-        pointer-events: none;
-        background: rgba(255, 0, 0, 0.5);
-        `;
-        $div.appendChild($dirtyRectangle);
-        canvas.addEventListener(CanvasEvent.DIRTY_RECTANGLE, (e) => {
-          const { dirtyRect } = e.detail;
-          const { x, y, width, height } = dirtyRect;
-          const dpr = window.devicePixelRatio;
-          // convert from canvas coords to viewport
-          $dirtyRectangle.style.left = `${x / dpr}px`;
-          $dirtyRectangle.style.top = `${y / dpr}px`;
-          $dirtyRectangle.style.width = `${width / dpr}px`;
-          $dirtyRectangle.style.height = `${height / dpr}px`;
-        });
-      }
 
       if (
         selectRenderer.value === 'canvas' &&

--- a/packages/g-mobile-webgl/package.json
+++ b/packages/g-mobile-webgl/package.json
@@ -45,7 +45,7 @@
     "@antv/g-plugin-html-renderer": "workspace:*",
     "@antv/g-plugin-image-loader": "workspace:*",
     "@antv/g-plugin-mobile-interaction": "workspace:*",
-    "@antv/g-device-api": "^1.3.6",
+    "@antv/g-device-api": "^1.6.10",
     "@antv/util": "^3.3.5",
     "tslib": "^2.5.3"
   },

--- a/packages/g-plugin-3d/package.json
+++ b/packages/g-plugin-3d/package.json
@@ -41,7 +41,7 @@
     "@antv/g-lite": "workspace:*",
     "@antv/g-plugin-device-renderer": "workspace:*",
     "@antv/g-shader-components": "workspace:*",
-    "@antv/g-device-api": "^1.3.6",
+    "@antv/g-device-api": "^1.6.10",
     "gl-matrix": "^3.4.3",
     "tslib": "^2.5.3"
   },

--- a/packages/g-plugin-device-renderer/package.json
+++ b/packages/g-plugin-device-renderer/package.json
@@ -43,7 +43,7 @@
     "@antv/g-plugin-image-loader": "workspace:*",
     "@antv/g-shader-components": "workspace:*",
     "@antv/util": "^3.3.5",
-    "@antv/g-device-api": "^1.3.6",
+    "@antv/g-device-api": "^1.6.10",
     "@webgpu/types": "^0.1.6",
     "earcut": "^2.2.3",
     "eventemitter3": "^5.0.1",

--- a/packages/g-webgl/package.json
+++ b/packages/g-webgl/package.json
@@ -44,7 +44,7 @@
     "@antv/g-plugin-html-renderer": "workspace:*",
     "@antv/g-plugin-image-loader": "workspace:*",
     "@antv/util": "^3.3.5",
-    "@antv/g-device-api": "^1.3.6",
+    "@antv/g-device-api": "^1.6.10",
     "tslib": "^2.5.3"
   },
   "devDependencies": {

--- a/packages/g-webgpu/package.json
+++ b/packages/g-webgpu/package.json
@@ -43,7 +43,7 @@
     "@antv/g-plugin-dom-interaction": "workspace:*",
     "@antv/g-plugin-html-renderer": "workspace:*",
     "@antv/g-plugin-image-loader": "workspace:*",
-    "@antv/g-device-api": "^1.3.6",
+    "@antv/g-device-api": "^1.6.10",
     "@antv/util": "^3.3.5",
     "@webgpu/types": "^0.1.6",
     "tslib": "^2.5.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 5.3.0
       playwright:
         specifier: latest
-        version: 1.40.1
+        version: 1.44.0
       pngjs:
         specifier: ^6.0.0
         version: 6.0.0
@@ -465,8 +465,8 @@ importers:
   packages/g-mobile-webgl:
     dependencies:
       '@antv/g-device-api':
-        specifier: ^1.3.6
-        version: 1.3.9
+        specifier: ^1.6.10
+        version: 1.6.10
       '@antv/g-lite':
         specifier: workspace:*
         version: link:../g-lite
@@ -517,8 +517,8 @@ importers:
   packages/g-plugin-3d:
     dependencies:
       '@antv/g-device-api':
-        specifier: ^1.3.6
-        version: 1.3.9
+        specifier: ^1.6.10
+        version: 1.6.10
       '@antv/g-lite':
         specifier: workspace:*
         version: link:../g-lite
@@ -703,8 +703,8 @@ importers:
   packages/g-plugin-device-renderer:
     dependencies:
       '@antv/g-device-api':
-        specifier: ^1.3.6
-        version: 1.3.9
+        specifier: ^1.6.10
+        version: 1.6.10
       '@antv/g-lite':
         specifier: workspace:*
         version: link:../g-lite
@@ -1045,8 +1045,8 @@ importers:
   packages/g-webgl:
     dependencies:
       '@antv/g-device-api':
-        specifier: ^1.3.6
-        version: 1.3.9
+        specifier: ^1.6.10
+        version: 1.6.10
       '@antv/g-lite':
         specifier: workspace:*
         version: link:../g-lite
@@ -1082,8 +1082,8 @@ importers:
   packages/g-webgpu:
     dependencies:
       '@antv/g-device-api':
-        specifier: ^1.3.6
-        version: 1.3.9
+        specifier: ^1.6.10
+        version: 1.6.10
       '@antv/g-lite':
         specifier: workspace:*
         version: link:../g-lite
@@ -1168,8 +1168,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
-  /@antv/g-device-api@1.3.9:
-    resolution: {integrity: sha512-73ilvcF6ToHzNl8w0dA/nE7s5e174/NzP93stfaXsHUDsZ0UItFWOH1TXHhuyrmGmhIAhKVF4sFXtk82MjIO6Q==}
+  /@antv/g-device-api@1.6.10:
+    resolution: {integrity: sha512-cuIEwIKvq8QdtZ+Ix/Mv9K8lJEAB2nrvPJPhH/Pj2FQeLRQiWGwHyyzsdgz4+uqAvEwtd2EX7lJ0A2Dwzl3NXA==}
     dependencies:
       '@antv/util': 3.3.5
       '@webgpu/types': 0.1.34
@@ -7589,18 +7589,18 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /playwright-core@1.40.1:
-    resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
+  /playwright-core@1.44.0:
+    resolution: {integrity: sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==}
     engines: {node: '>=16'}
     hasBin: true
     dev: true
 
-  /playwright@1.40.1:
-    resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
+  /playwright@1.44.0:
+    resolution: {integrity: sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright-core: 1.40.1
+      playwright-core: 1.44.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

In WebXR there're multiple XRViews e.g. left and right eyes. So we need to support rendering to cameras instead of a single camera.

https://threejs.org/docs/#api/en/cameras/ArrayCamera

### 💡 Background and solution

Since we use RenderGraph now, each camera should have its own render pass.

```ts
this.cameras.forEach(({ viewport }) => {
    // main render pass
    this.builder.pushPass((pass) => {});
});
```

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
