### PR TITLE
fix: fix canvas.ready never resolve when switch to webgl, webgpu renderer

### DIFF
--- a/__tests__/demos/canvas/index.ts
+++ b/__tests__/demos/canvas/index.ts
@@ -1,0 +1,1 @@
+export { switchRenderer } from './switch-renderer';

--- a/__tests__/demos/canvas/switch-renderer.ts
+++ b/__tests__/demos/canvas/switch-renderer.ts
@@ -1,0 +1,37 @@
+import { Circle } from '../../../packages/g';
+import { Renderer as CanvasRenderer } from '../../../packages/g-canvas';
+import { Renderer as SVGRenderer } from '../../../packages/g-svg';
+import { Renderer as WebGLRenderer } from '../../../packages/g-webgl';
+
+export async function switchRenderer(context) {
+  const { canvas, gui } = context;
+
+  await canvas.ready;
+
+  const circle = new Circle({
+    style: {
+      cx: 100,
+      cy: 100,
+      r: 50,
+      fill: 'red',
+    },
+  });
+
+  canvas.appendChild(circle);
+
+  const folder = gui.addFolder('renderer');
+  folder
+    .add({ renderer: 'canvas' }, 'renderer', ['canvas', 'svg', 'webgl'])
+    .onChange((name) => {
+      let renderer;
+      if (name === 'canvas') renderer = new CanvasRenderer();
+      else if (name === 'svg') renderer = new SVGRenderer();
+      else if (name === 'webgl') renderer = new WebGLRenderer();
+
+      canvas.setRenderer(renderer);
+
+      canvas.ready.then(() => {
+        alert(`Switch to ${name} renderer`);
+      });
+    });
+}

--- a/__tests__/main.ts
+++ b/__tests__/main.ts
@@ -18,6 +18,7 @@ import * as perf from './demos/perf';
 import * as bugfix from './demos/bugfix';
 import * as event from './demos/event';
 import * as camera from './demos/camera';
+import * as canvasCase from './demos/canvas';
 
 const tests = {
   ...createSpecRender(namespace(basic2d, '2d')),
@@ -31,6 +32,7 @@ const tests = {
   ...createSpecRender(namespace(perf, 'perf')),
   ...createSpecRender(namespace(event, 'event')),
   ...createSpecRender(namespace(camera, 'camera')),
+  ...createSpecRender(namespace(canvasCase, 'canvas')),
 };
 
 const renderers = {

--- a/packages/g-lite/src/Canvas.ts
+++ b/packages/g-lite/src/Canvas.ts
@@ -570,11 +570,12 @@ export class Canvas extends EventTarget implements ICanvas {
         } else {
           this.dispatchEvent(new CustomEvent(CanvasEvent.READY));
         }
-        if (this.readyPromise) {
-          this.resolveReadyPromise();
-        }
       } else {
         this.dispatchEvent(new CustomEvent(CanvasEvent.RENDERER_CHANGED));
+      }
+
+      if (this.readyPromise) {
+        this.resolveReadyPromise();
       }
 
       if (!firstContentfullPaint) {


### PR DESCRIPTION
* 修复调用 `setRenderer` 切换渲染器后立即获取 `canvas.ready` 无法 resolve 的问题

> 原因是切换到 `canvas` 、 `svg` 渲染器是同步操作，而 `webgl` `webgpu` 是异步操作，导致获取 `canvas.ready` 前 this.inited 为 false，resolveReadyPromise 又仅在首次绘制时执行，故导致 ready 永远无法 resolve