### PR TITLE
fix: `HTML` element bounding box calculation logic #1743

### DIFF
--- a/.changeset/friendly-avocados-drum.md
+++ b/.changeset/friendly-avocados-drum.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: HTML element bounding box calculation logic (#1743)

--- a/demo/camera+html.html
+++ b/demo/camera+html.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,user-scalable=no,initial-scale=1,shrink-to-fit=no"
+    />
+    <title>Camera</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        height: 100vh;
+      }
+
+      #container {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="container"></div>
+    <script
+      src="../packages/g/dist/index.umd.min.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../packages/g-canvas/dist/index.umd.min.js"
+      type="application/javascript"
+    ></script>
+    <script src="../packages/g-plugin-control/dist/index.umd.min.js"></script>
+    <!-- <script src="../packages/g-svg/dist/index.umd.min.js" type="application/javascript"></script>
+    <script src="../packages/g-webgl/dist/index.umd.min.js" type="application/javascript"></script> -->
+    <script>
+      console.log(window.G);
+      const { Circle, CanvasEvent, Canvas, HTML } = window.G;
+
+      // create a renderer
+      const canvasRenderer = new window.G.Canvas2D.Renderer();
+      canvasRenderer.registerPlugin(new window.G.Control.Plugin());
+
+      // create a canvas
+      const canvas = new Canvas({
+        container: 'container',
+        width: 800,
+        height: 800,
+        renderer: canvasRenderer,
+      });
+
+      const circle = new Circle({
+        style: {
+          cx: 200,
+          cy: 200,
+          r: 50,
+          fill: 'red',
+        },
+      });
+
+      const html = new HTML({
+        style: {
+          x: 150,
+          y: 150,
+          width: 100,
+          height: 100,
+          innerHTML:
+            '<h1 style="width: 100px; height: 100px;">This is Title</h1>',
+        },
+      });
+
+      canvas.addEventListener(CanvasEvent.READY, () => {
+        canvas.appendChild(circle);
+        canvas.appendChild(html);
+
+        console.log('canvas.getCamera()', canvas.getCamera(), circle, html);
+        console.log(
+          'circle',
+          'getBoundingClientRect',
+          circle.getBoundingClientRect(),
+          'getBounds',
+          circle.getBounds(),
+        );
+        console.log(
+          'html',
+          'getBoundingClientRect',
+          html.getBoundingClientRect(),
+          'getBounds',
+          html.getBounds(),
+        );
+
+        console.log('Camera pan(-50, 50) --------------------------');
+        canvas.getCamera().pan(-50, 50);
+        requestAnimationFrame(() => {
+          console.log(
+            'circle',
+            'getBoundingClientRect',
+            circle.getBoundingClientRect(),
+            'getBounds',
+            circle.getBounds(),
+          );
+          console.log(
+            'html',
+            'getBoundingClientRect',
+            html.getBoundingClientRect(),
+            'getBounds',
+            html.getBounds(),
+          );
+
+          console.log('Camera setZoom(1.2) --------------------------');
+          canvas.getCamera().setZoom(1.2);
+          requestAnimationFrame(() => {
+            console.log(
+              'circle',
+              'getBoundingClientRect',
+              circle.getBoundingClientRect(),
+              'getBounds',
+              circle.getBounds(),
+            );
+            console.log(
+              'html',
+              'getBoundingClientRect',
+              html.getBoundingClientRect(),
+              'getBounds',
+              html.getBounds(),
+            );
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/packages/g-lite/src/display-objects/HTML.ts
+++ b/packages/g-lite/src/display-objects/HTML.ts
@@ -64,7 +64,15 @@ export class HTML extends DisplayObject<HTMLStyleProps, ParsedHTMLStyleProps> {
    */
   getBoundingClientRect(): Rectangle {
     if (this.parsedStyle.$el) {
-      return this.parsedStyle.$el.getBoundingClientRect();
+      const cameraMatrix = this.ownerDocument.defaultView
+        .getCamera()
+        .getOrthoMatrix();
+      const bBox = this.parsedStyle.$el.getBoundingClientRect();
+
+      return Rectangle.applyTransform(
+        bBox,
+        mat4.invert(mat4.create(), cameraMatrix),
+      );
     } else {
       const { x, y, width, height } = this.parsedStyle;
       return new Rectangle(x, y, width, height);

--- a/packages/g-lite/src/shapes/Rectangle.ts
+++ b/packages/g-lite/src/shapes/Rectangle.ts
@@ -1,9 +1,87 @@
+import { mat4, vec4 } from 'gl-matrix';
+
+type RectangleLike = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 export class Rectangle implements DOMRect {
+  /**
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMRect/fromRect_static
+   */
+  static fromRect(rect: RectangleLike) {
+    return new Rectangle(rect.x, rect.y, rect.width, rect.height);
+  }
+
+  /**
+   * will return a new rect instance
+   */
+  static applyTransform(rect: Rectangle, matrix: mat4) {
+    const topLeft = vec4.fromValues(rect.x, rect.y, 0, 1);
+    const topRight = vec4.fromValues(rect.x + rect.width, rect.y, 0, 1);
+    const bottomLeft = vec4.fromValues(rect.x, rect.y + rect.height, 0, 1);
+    const bottomRight = vec4.fromValues(
+      rect.x + rect.width,
+      rect.y + rect.height,
+      0,
+      1,
+    );
+
+    const transformedTopLeft = vec4.create();
+    const transformedTopRight = vec4.create();
+    const transformedBottomLeft = vec4.create();
+    const transformedBottomRight = vec4.create();
+
+    vec4.transformMat4(transformedTopLeft, topLeft, matrix);
+    vec4.transformMat4(transformedTopRight, topRight, matrix);
+    vec4.transformMat4(transformedBottomLeft, bottomLeft, matrix);
+    vec4.transformMat4(transformedBottomRight, bottomRight, matrix);
+
+    const minX = Math.min(
+      transformedTopLeft[0],
+      transformedTopRight[0],
+      transformedBottomLeft[0],
+      transformedBottomRight[0],
+    );
+    const minY = Math.min(
+      transformedTopLeft[1],
+      transformedTopRight[1],
+      transformedBottomLeft[1],
+      transformedBottomRight[1],
+    );
+    const maxX = Math.max(
+      transformedTopLeft[0],
+      transformedTopRight[0],
+      transformedBottomLeft[0],
+      transformedBottomRight[0],
+    );
+    const maxY = Math.max(
+      transformedTopLeft[1],
+      transformedTopRight[1],
+      transformedBottomLeft[1],
+      transformedBottomRight[1],
+    );
+
+    return Rectangle.fromRect({
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
+    });
+  }
+
   left: number;
   right: number;
   top: number;
   bottom: number;
-  constructor(public x: number, public y: number, public width: number, public height: number) {
+  constructor(
+    public x: number,
+    public y: number,
+    public width: number,
+    public height: number,
+  ) {
     this.left = x;
     this.right = x + width;
     this.top = y;


### PR DESCRIPTION
Subtract the camera's transformation from the bounding box calculation logic of the `HTML` element to keep the result consistent with the native canvas element

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

- fixed #1743

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Detailed questions can be found #1743 .

The root cause is that the camera transformation and element transformation of G are independent, which means that if only the camera is adjusted, the transformation of the canvas element will not change.

However, the implementation of `getBoundingClientRect()` of `HTML` type elements simply calls the DOM API, because the transformation of the camera `div` element as the parent element is also included, which is inconsistent with the calculation logic of the canvas element.

Therefore, the camera transformation needs to be eliminated in the implementation of `getBoundingClientRect()` of `HTML` type elements.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix: subtract the camera's transformation from the bounding box calculation logic of the `HTML` element to keep the result consistent with the native canvas element (#1743)  |
| 🇨🇳 Chinese |  fix: `HTML` 元素包围盒计算逻辑中减去相机的变换，保持和原生 canvas 元素的结果一致 (#1743) |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
