### PR TITLE
fix: HTML canvas does not match the canvas range after the camera is applied (#1702)

### DIFF
--- a/.changeset/funny-tigers-leave.md
+++ b/.changeset/funny-tigers-leave.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-plugin-html-renderer': patch
+---
+
+fix: HTML canvas does not match the canvas range after the camera is applied (#1702)

--- a/packages/g-plugin-html-renderer/src/HTMLRenderingPlugin.ts
+++ b/packages/g-plugin-html-renderer/src/HTMLRenderingPlugin.ts
@@ -176,6 +176,17 @@ export class HTMLRenderingPlugin implements RenderingPlugin {
         '#' + cameraId,
       );
       if (!$existedCamera) {
+        // fix @see https://github.com/antvis/G/issues/1702
+        const $cameraContainer = (doc || document).createElement('div');
+        // HTML elements should not overflow with canvas @see https://github.com/antvis/G/issues/1163
+        $cameraContainer.style.overflow = 'hidden';
+        $cameraContainer.style.pointerEvents = 'none';
+        $cameraContainer.style.position = 'absolute';
+        $cameraContainer.style.left = `0px`;
+        $cameraContainer.style.top = `0px`;
+        $cameraContainer.style.width = `${width || 0}px`;
+        $cameraContainer.style.height = `${height || 0}px`;
+
         const $camera = (doc || document).createElement('div');
         $existedCamera = $camera;
         $camera.id = cameraId;
@@ -188,13 +199,12 @@ export class HTMLRenderingPlugin implements RenderingPlugin {
         $camera.style.transform = this.joinTransformMatrix(
           camera.getOrthoMatrix(),
         );
-        // HTML elements should not overflow with canvas @see https://github.com/antvis/G/issues/1163
-        $camera.style.overflow = 'hidden';
         $camera.style.pointerEvents = 'none';
-        $camera.style.width = `${width || 0}px`;
-        $camera.style.height = `${height || 0}px`;
+        $camera.style.width = `100%`;
+        $camera.style.height = `100%`;
 
-        $container.appendChild($camera);
+        $cameraContainer.appendChild($camera);
+        $container.appendChild($cameraContainer);
       }
 
       return $existedCamera;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1702 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

When the html canvas uses a div element as a container, the camera's transformation will be applied to the div element, so that after the user pans or zooms, the div cannot maintain the same width and height as the canvas element. As a container for rendering html elements, this will cause some problems, such as #1702 .

The solution is to add an additional div element as the html canvas container, whose direct child element is the camera's div element. In this hierarchical structure, the camera's transformation and rendering container are independent and do not affect each other. The html container div will always remain consistent with the canvas element.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: HTML canvas does not match the canvas range after the camera is applied (#1702)  |
| 🇨🇳 Chinese | fix: html 画布在相机作用下不能和 canvas 画布范围保持一致 (#1702 ) |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
