### PR TITLE
fix: `path` elements are drawn incorrectly

### DIFF
--- a/.changeset/two-parrots-film.md
+++ b/.changeset/two-parrots-film.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-plugin-canvas-path-generator': patch
+---
+
+fix: `path` elements are drawn incorrectly after using `markerStartOffset` (#1760)

--- a/demo/issues/issue-1760.html
+++ b/demo/issues/issue-1760.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,user-scalable=no,initial-scale=1,shrink-to-fit=no"
+    />
+    <title>issue-1760</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        height: 100vh;
+      }
+
+      #container {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="container"></div>
+    <script
+      src="../../packages/g/dist/index.umd.min.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../../packages/g-canvas/dist/index.umd.min.js"
+      type="application/javascript"
+    ></script>
+    <script type="module">
+      // @see https://github.com/antvis/G/issues/1760
+      const { Canvas, Path, Line, Canvas2D } = window.G;
+
+      const canvasRenderer = new Canvas2D.Renderer();
+
+      const canvas = new Canvas({
+        container: 'container',
+        width: 600,
+        height: 500,
+        renderer: canvasRenderer,
+      });
+
+      const arrowMarker = new Path({
+        style: {
+          d: 'M 10,10 L -10,0 L 10,-10 Z',
+          stroke: '#1890FF',
+          transformOrigin: 'center',
+        },
+      });
+
+      const path = new Path({
+        style: {
+          lineWidth: 1,
+          stroke: '#54BECC',
+          // d: 'M 0,40 L 100,100',
+          d: 'M 10,100 L 100,100',
+          markerStart: arrowMarker,
+          markerStartOffset: 30,
+          markerEnd: arrowMarker,
+          markerEndOffset: 30,
+        },
+      });
+
+      const line = new Line({
+        style: {
+          x1: 10,
+          y1: 150,
+          x2: 100,
+          y2: 150,
+          lineWidth: 1,
+          stroke: '#54BECC',
+          markerStart: arrowMarker,
+          markerStartOffset: 30,
+          markerEnd: arrowMarker,
+          markerEndOffset: 30,
+        },
+      });
+
+      canvas.appendChild(path);
+      canvas.appendChild(line);
+    </script>
+  </body>
+</html>

--- a/packages/g-plugin-canvas-path-generator/src/paths/Path.ts
+++ b/packages/g-plugin-canvas-path-generator/src/paths/Path.ts
@@ -54,7 +54,6 @@ export function generatePath(
         // Use start marker offset
         if (useStartOffset) {
           context.moveTo(params[1] + startOffsetX, params[2] + startOffsetY);
-          context.lineTo(params[1], params[2]);
         } else {
           context.moveTo(params[1], params[2]);
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1760 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

see #1760 

The drawing command generation logic of the path element is abnormal. For the processing of the `M` command, redundant `lineTo` logic is added. Just remove the logic.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: `path` elements are drawn incorrectly after using `markerStartOffset` (#1760)  |
| 🇨🇳 Chinese | fix: path 元素在使用 `markerStartOffset` 后绘制异常  |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
