### PR TITLE
fix: html element's `getBounds` logic exception (#1743)

### DIFF
--- a/.changeset/silver-chicken-heal.md
+++ b/.changeset/silver-chicken-heal.md
@@ -1,0 +1,6 @@
+---
+'@antv/g-plugin-html-renderer': patch
+'@antv/g-lite': patch
+---
+
+fix: html element's `getBounds` logic exception (#1743)

--- a/demo/issues/issue-1743.html
+++ b/demo/issues/issue-1743.html
@@ -14,12 +14,15 @@
         padding: 0;
       }
 
-      html,
       body {
         height: 100vh;
+        padding: 111px 0 0 111px;
+        /* padding: 100px 0 0 100px; */
       }
 
       #container {
+        /* border: 1px solid #ddd; */
+        background-color: #ddd;
         width: 100%;
         height: 100%;
       }
@@ -29,16 +32,14 @@
   <body>
     <div id="container"></div>
     <script
-      src="../packages/g/dist/index.umd.min.js"
+      src="../../packages/g/dist/index.umd.min.js"
       type="application/javascript"
     ></script>
     <script
-      src="../packages/g-canvas/dist/index.umd.min.js"
+      src="../../packages/g-canvas/dist/index.umd.min.js"
       type="application/javascript"
     ></script>
-    <script src="../packages/g-plugin-control/dist/index.umd.min.js"></script>
-    <!-- <script src="../packages/g-svg/dist/index.umd.min.js" type="application/javascript"></script>
-    <script src="../packages/g-webgl/dist/index.umd.min.js" type="application/javascript"></script> -->
+    <script src="../../packages/g-plugin-control/dist/index.umd.min.js"></script>
     <script>
       console.log(window.G);
       const { Circle, CanvasEvent, Canvas, HTML } = window.G;
@@ -50,8 +51,8 @@
       // create a canvas
       const canvas = new Canvas({
         container: 'container',
-        width: 800,
-        height: 800,
+        width: 600,
+        height: 600,
         renderer: canvasRenderer,
       });
 
@@ -61,6 +62,9 @@
           cy: 200,
           r: 50,
           fill: 'red',
+          transform: 'translate(120px, 120px) scale(2)',
+          transformOrigin: 'center center',
+          // transformOrigin: '200px 200px',
         },
       });
 
@@ -72,12 +76,21 @@
           height: 100,
           innerHTML:
             '<h1 style="width: 100px; height: 100px;">This is Title</h1>',
+          transform: 'translate(120px, 120px) scale(2)',
+          transformOrigin: 'center center',
+          // transformOrigin: '50px 50px',
         },
       });
 
       canvas.addEventListener(CanvasEvent.READY, () => {
         canvas.appendChild(circle);
         canvas.appendChild(html);
+
+        // console.log(
+        //   'transform',
+        //   circle.getWorldTransform(),
+        //   html.getWorldTransform(),
+        // );
 
         console.log('canvas.getCamera()', canvas.getCamera(), circle, html);
         console.log(

--- a/packages/g-lite/src/display-objects/HTML.ts
+++ b/packages/g-lite/src/display-objects/HTML.ts
@@ -1,7 +1,7 @@
 import { mat4 } from 'gl-matrix';
 import type { DisplayObjectConfig } from '../dom';
 import { runtime } from '../global-runtime';
-import { AABB, Rectangle } from '../shapes';
+import { AABB } from '../shapes';
 import type { BaseStyleProps, ParsedBaseStyleProps } from '../types';
 import { Shape } from '../types';
 import { DisplayObject } from './DisplayObject';
@@ -61,45 +61,39 @@ export class HTML extends DisplayObject<HTMLStyleProps, ParsedHTMLStyleProps> {
   /**
    * override with $el.getBoundingClientRect
    * @see https://developer.mozilla.org/zh-CN/docs/Web/API/Element/getBoundingClientRect
+   *
+   * ! The calculation logic of the html element should be consistent with that of the canvas element
    */
-  getBoundingClientRect(): Rectangle {
-    if (this.parsedStyle.$el) {
-      const cameraMatrix = this.ownerDocument.defaultView
-        .getCamera()
-        .getOrthoMatrix();
-      const bBox = this.parsedStyle.$el.getBoundingClientRect();
-
-      return Rectangle.applyTransform(
-        bBox,
-        mat4.invert(mat4.create(), cameraMatrix),
-      );
-    } else {
-      const { x, y, width, height } = this.parsedStyle;
-      return new Rectangle(x, y, width, height);
-    }
-  }
+  // getBoundingClientRect(): Rectangle {
+  //   if (this.parsedStyle.$el) {
+  //     return this.parsedStyle.$el.getBoundingClientRect();
+  //   } else {
+  //     const { x, y, width, height } = this.parsedStyle;
+  //     return new Rectangle(x, y, width, height);
+  //   }
+  // }
 
   getClientRects() {
     return [this.getBoundingClientRect()];
   }
 
-  getBounds() {
-    const clientRect = this.getBoundingClientRect();
-    // calc context's offset
-    // @ts-ignore
-    const canvasRect = this.ownerDocument?.defaultView
-      ?.getContextService()
-      .getBoundingClientRect();
+  // getBounds() {
+  //   const clientRect = this.getBoundingClientRect();
+  //   // calc context's offset
+  //   // @ts-ignore
+  //   const canvasRect = this.ownerDocument?.defaultView
+  //     ?.getContextService()
+  //     .getBoundingClientRect();
 
-    const aabb = new AABB();
-    const minX = clientRect.left - (canvasRect?.left || 0);
-    const minY = clientRect.top - (canvasRect?.top || 0);
-    aabb.setMinMax(
-      [minX, minY, 0],
-      [minX + clientRect.width, minY + clientRect.height, 0],
-    );
-    return aabb;
-  }
+  //   const aabb = new AABB();
+  //   const minX = clientRect.left - (canvasRect?.left || 0);
+  //   const minY = clientRect.top - (canvasRect?.top || 0);
+  //   aabb.setMinMax(
+  //     [minX, minY, 0],
+  //     [minX + clientRect.width, minY + clientRect.height, 0],
+  //   );
+  //   return aabb;
+  // }
 
   getLocalBounds() {
     if (this.parentNode) {

--- a/packages/g-lite/src/global-runtime.ts
+++ b/packages/g-lite/src/global-runtime.ts
@@ -42,6 +42,7 @@ import {
   RectUpdater,
   TextService,
   TextUpdater,
+  HTMLUpdater,
 } from './services';
 import { CanvasLike, Shape } from './types';
 
@@ -104,7 +105,7 @@ const geometryUpdaterFactory: Record<Shape, GeometryAABBUpdater<any>> = (() => {
     [Shape.POLYLINE]: polylineUpdater,
     [Shape.POLYGON]: polylineUpdater,
     [Shape.PATH]: new PathUpdater(),
-    [Shape.HTML]: null,
+    [Shape.HTML]: new HTMLUpdater(),
     [Shape.MESH]: null,
   };
 })();

--- a/packages/g-lite/src/services/aabb/HTMLUpdater.ts
+++ b/packages/g-lite/src/services/aabb/HTMLUpdater.ts
@@ -1,0 +1,15 @@
+import type { HTML, ParsedHTMLStyleProps } from '../../display-objects/HTML';
+import type { GeometryAABBUpdater } from './interfaces';
+
+export class HTMLUpdater implements GeometryAABBUpdater<ParsedHTMLStyleProps> {
+  update(parsedStyle: ParsedHTMLStyleProps, object: HTML) {
+    const { x = 0, y = 0, width = 0, height = 0 } = parsedStyle;
+
+    return {
+      cx: x + width / 2,
+      cy: y + height / 2,
+      hwidth: width / 2,
+      hheight: height / 2,
+    };
+  }
+}

--- a/packages/g-lite/src/services/aabb/index.ts
+++ b/packages/g-lite/src/services/aabb/index.ts
@@ -7,3 +7,4 @@ export { PolylineUpdater } from './PolylineUpdater';
 export { RectUpdater } from './RectUpdater';
 export { TextUpdater } from './TextUpdater';
 export { GroupUpdater } from './GroupUpdater';
+export { HTMLUpdater } from './HTMLUpdater';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1743 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

In #1744, the problem was partially solved by removing the camera's transformation matrix from the result of getBoundingClientRect() on the html element, but the problem still occurred when the drawing canvas element was not in the top left corner of the page (i.e. left/top was not equal to 0).

In order to completely solve this problem, we deeply analyzed the logical differences between the same methods of the canvas element and the html element, and found that their calculation logic is opposite. For the canvas element, the calculation of `getBoundingClientRect()` depends on the result of `getBounds()`, while for html it is the opposite. At the same time, this leads to a serious problem, that is, the calculation results of `getBoundingClientRect()` of the canvas element are inconsistent with those of `getBoundingClientRect()` of dom in some cases.

There are two options to solve this problem. The first option is to make the calculation logic of `getBoundingClientRect()` of the canvas element consistent with that of the dom. This seems difficult because there are a lot of differences in details between the matrix transformation of the dom and the matrix transformation of the canvas. The second option is to adjust the calculation logic of the html element to be consistent with that of the canvas. Although this will lead to inconsistencies with the calculation results of `getBoundingClientRect()` of the dom, it at least ensures the consistency between the html element and the canvas element.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: html element's `getBounds` logic exception (#1743) |
| 🇨🇳 Chinese | fix: html 元素的 `getBounds` 逻辑异常 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
