### PR TITLE
fix: wrong y coordinate when picking with webgl (#1747)

### DIFF
--- a/.changeset/cool-crews-sneeze.md
+++ b/.changeset/cool-crews-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-plugin-device-renderer': patch
+---
+
+fix: wrong y coordinate when picking with webgl (#1747)

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,6 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "arrowParens": "always",
-  "printWidth": 120,
+  "printWidth": 80,
   "proseWrap": "never"
 }

--- a/__tests__/demos/bugfix/1747.ts
+++ b/__tests__/demos/bugfix/1747.ts
@@ -1,0 +1,58 @@
+import { Text, Path, Rect } from '@antv/g';
+
+export async function test_pick(context) {
+  const { canvas } = context;
+  await canvas.ready;
+
+  const test = (shape, property) => {
+    shape.addEventListener('pointerenter', () => {
+      shape.style[property] = 'red';
+    });
+    shape.addEventListener('pointerleave', () => {
+      shape.style[property] = 'black';
+    });
+  };
+
+  const text = new Text({
+    style: {
+      text: 'test123213',
+      fontSize: 20,
+      x: 300,
+      y: 300,
+      cursor: 'pointer',
+      // transform: 'rotate(45)',
+    },
+  });
+  console.log(text.getBounds());
+
+  const path = new Path({
+    style: {
+      d: 'M 100,100 L 150,100 L 150,150 Z',
+      fill: 'black',
+      // transform: 'rotate(45)',
+      cursor: 'pointer',
+    },
+  });
+
+  test(text, 'fill');
+  test(path, 'fill');
+
+  canvas.appendChild(text);
+  // canvas.appendChild(path);
+
+  const { x, y, width, height } = text.getBBox();
+  const rect = new Rect({
+    style: {
+      x,
+      y,
+      width,
+      height,
+      stroke: 'black',
+      // transform: 'rotate(45)',
+      cursor: 'pointer',
+    },
+  });
+  test(rect, 'stroke');
+
+  // canvas.appendChild(rect);
+}

--- a/__tests__/demos/bugfix/index.ts
+++ b/__tests__/demos/bugfix/index.ts
@@ -6,3 +6,4 @@ export { image } from './1636';
 export { shadowroot_offset } from './1677';
 export { gradient_text } from './1572';
 export { zoom } from './1667';
+export { test_pick } from './1747';

--- a/packages/g-plugin-device-renderer/src/PickingPlugin.ts
+++ b/packages/g-plugin-device-renderer/src/PickingPlugin.ts
@@ -338,7 +338,8 @@ export class PickingPlugin implements RenderingPlugin {
       canvasWidth * dpr,
       canvasHeight * dpr,
       x,
-      y,
+      // fix https://github.com/antvis/G/issues/1747
+      canvasHeight * dpr - y,
       width,
       height,
     );

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import process from 'process';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, URL } from 'url';
 import { defineConfig } from 'vite';
 import glslify from 'rollup-plugin-glslify';
 import commonjs from '@rollup/plugin-commonjs';
@@ -8,7 +8,7 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const resolve = (packageName) => {
   return path.resolve(__dirname, path.join('./packages/', packageName, process.env.CI ? 'dist/index.esm.js' : 'src'));


### PR DESCRIPTION
---------

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1747 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

see #1747 

Because the y axis of the drawing coordinate system is downward, and the camera coordinate system is a right-handed coordinate system with its y axis pointing upward. Therefore, we only need to flip the y axis of the drawing coordinate system and pass it to the camera coordinate system.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: wrong y coordinate when picking with webgl (#1747) |
| 🇨🇳 Chinese | fix: webgl 拾取时 y 坐标错误 (#1747) |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
