### PR TITLE
chore: remove prerelease script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test:serverside": "jest --config jest.node.config.js",
     "changeset": "changeset",
     "version": "changeset version",
-    "prerelease": "changeset pre enter next",
     "release": "changeset publish --tag latest",
     "wasm": "wasm-pack build ./rust --target web",
     "watch": "pnpm --parallel -r run watch"


### PR DESCRIPTION
- prerelease 会导致发布过程进入 pre mode，原因不明