### PR TITLE
fix: when an element is destroyed, its child elements are not destroyed

### DIFF
--- a/.changeset/three-fishes-grow.md
+++ b/.changeset/three-fishes-grow.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: when an element is destroyed, its child elements are not destroyed

--- a/__tests__/demos/perf/canvas-api.ts
+++ b/__tests__/demos/perf/canvas-api.ts
@@ -1,0 +1,76 @@
+import * as lil from 'lil-gui';
+import { type Canvas } from '@antv/g';
+import * as tinybench from 'tinybench';
+
+export async function canvasApi(context: { canvas: Canvas; gui: lil.GUI }) {
+  const { canvas } = context;
+  console.log(canvas);
+
+  await canvas.ready;
+
+  // benchmark
+  // ----------
+  const bench = new tinybench.Bench({ name: 'canvas benchmark', time: 100 });
+
+  const canvasContext = canvas
+    .getContextService()
+    .getContext() as CanvasRenderingContext2D;
+  const offscreenCanvas = new OffscreenCanvas(
+    canvas.getConfig().width,
+    canvas.getConfig().height,
+  ).getContext('2d');
+  const props = {
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    filter: 'none',
+  };
+  const propsKeys = Object.keys(props);
+
+  bench.add('get object props', () => {
+    propsKeys.forEach((key) => {
+      props[key];
+    });
+  });
+  bench.add('set object props', () => {
+    propsKeys.forEach((key) => {
+      props[key] = props[key];
+    });
+  });
+
+  propsKeys.forEach((key) => {
+    bench.add(`get canvas context props - ${key}`, async () => {
+      canvasContext[key];
+    });
+    bench.add(`set canvas context props - ${key}`, async () => {
+      canvasContext[key] = canvasContext[key];
+    });
+  });
+  bench.add('canvas context save() & restore()', async () => {
+    canvasContext.save();
+    canvasContext.restore();
+  });
+
+  propsKeys.forEach((key) => {
+    bench.add(`get offscreenCanvas context props - ${key}`, async () => {
+      offscreenCanvas[key];
+    });
+    bench.add(`set offscreenCanvas context props - ${key}`, async () => {
+      offscreenCanvas[key] = canvasContext[key];
+    });
+  });
+  bench.add('canvas offscreenCanvas save() & restore()', async () => {
+    offscreenCanvas.save();
+    offscreenCanvas.restore();
+  });
+
+  await bench.run();
+
+  console.log(bench.name);
+  console.table(bench.table());
+  console.log(bench.results);
+  console.log(bench.tasks);
+
+  // ----------
+}

--- a/__tests__/demos/perf/image.ts
+++ b/__tests__/demos/perf/image.ts
@@ -1,4 +1,4 @@
-import { Canvas, Image as GImage } from '@antv/g';
+import { Canvas, Group, Image as GImage } from '@antv/g';
 import * as lil from 'lil-gui';
 
 export async function image(context: { canvas: Canvas; gui: lil.GUI }) {
@@ -6,6 +6,7 @@ export async function image(context: { canvas: Canvas; gui: lil.GUI }) {
   await canvas.ready;
   console.log(canvas);
 
+  const group = new Group();
   let image = new GImage({
     style: {
       x: 0,
@@ -17,7 +18,9 @@ export async function image(context: { canvas: Canvas; gui: lil.GUI }) {
       src: 'https://mdn.alipayobjects.com/huamei_fr7vu1/afts/img/A*SqloToP7R9QAAAAAAAAAAAAADkn0AQ/original',
     },
   });
-  canvas.appendChild(image);
+
+  group.appendChild(image);
+  canvas.appendChild(group);
 
   // ---
   const $dom = canvas.getContextService().getDomElement() as HTMLCanvasElement;

--- a/__tests__/demos/perf/javascript.ts
+++ b/__tests__/demos/perf/javascript.ts
@@ -1,0 +1,120 @@
+import * as lil from 'lil-gui';
+import { type Canvas } from '@antv/g';
+import * as tinybench from 'tinybench';
+import { isNil } from '@antv/util';
+
+export async function javascript(context: { canvas: Canvas; gui: lil.GUI }) {
+  const { canvas } = context;
+  console.log(canvas);
+
+  await canvas.ready;
+
+  // benchmark
+  // ----------
+  const bench = new tinybench.Bench({ name: 'canvas benchmark', time: 1e2 });
+  const array = [
+    'stroke',
+    'shadowType',
+    'shadowOffsetX',
+    'shadowOffsetY',
+    'shadowBlur',
+    'lineWidth',
+    'increasedLineWidthForHitTesting',
+    'lineJoin',
+    'lineCap',
+    'dx',
+    'dy',
+    'filter',
+    'textPathStartOffset',
+    'transformOrigin',
+    'cx',
+    'cy',
+    'cz',
+    'r',
+    'rx',
+    'ry',
+    'x',
+    'y',
+    'z',
+    'width',
+    'height',
+    'radius',
+    'x1',
+    'y1',
+    'z1',
+    'x2',
+    'y2',
+    'z2',
+    'd',
+    'points',
+    'text',
+    'textTransform',
+    'font',
+    'fontSize',
+    'fontFamily',
+    'fontStyle',
+    'fontWeight',
+    'fontVariant',
+    'lineHeight',
+    'letterSpacing',
+    'miterLimit',
+    'wordWrap',
+    'wordWrapWidth',
+    'maxLines',
+    'textOverflow',
+    'leading',
+    'textBaseline',
+    'textAlign',
+    'markerStartOffset',
+    'markerEndOffset',
+  ];
+  const object = { stroke: '', fill: '' };
+
+  // bench.add('for', async () => {
+  //   for (let i = 0; i < array.length; i++) {
+  //     if (array[i] in object) {
+  //       break;
+  //     }
+  //   }
+  // });
+  // bench.add('for & typeof', async () => {
+  //   for (let i = 0; i < array.length; i++) {
+  //     if (typeof object[array[i]] !== 'undefined') {
+  //       break;
+  //     }
+  //   }
+  // });
+  // bench.add('object.keys', async () => {
+  //   Object.keys(object).some((name) => array.includes(name));
+  // });
+  // bench.add('array.some', async () => {
+  //   array.some((name) => name in object);
+  // });
+
+  // const value = '';
+  // bench.add('typeof - isNil', async () => {
+  //   !(typeof value === 'undefined' || value === null);
+  // });
+  // bench.add('@antv/util - isNil', async () => {
+  //   !isNil(value);
+  // });
+
+  const stringKey = 'fill';
+  const objectKey = { a: 1 };
+  const map = new Map();
+  bench.add('Map set - stringKey', async () => {
+    map.set(stringKey, 1);
+  });
+  bench.add('Map set - objectKey', async () => {
+    map.set(objectKey, 1);
+  });
+
+  await bench.run();
+
+  console.log(bench.name);
+  console.table(bench.table());
+  console.log(bench.results);
+  console.log(bench.tasks);
+
+  // ----------
+}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "simplex-noise": "^3.0.0",
     "sinon": "^11.1.2",
     "stats.js": "^0.17.0",
+    "tinybench": "^3.0.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.6.2",
     "vite": "^3.2.7",

--- a/packages/g-lite/src/display-objects/DisplayObject.ts
+++ b/packages/g-lite/src/display-objects/DisplayObject.ts
@@ -68,8 +68,8 @@ const $quat = quat.create();
  * * attributeChanged
  */
 export class DisplayObject<
-  StyleProps extends BaseStyleProps = BaseStyleProps,
-  ParsedStyleProps extends ParsedBaseStyleProps = ParsedBaseStyleProps,
+  StyleProps extends BaseStyleProps = any,
+  ParsedStyleProps extends ParsedBaseStyleProps = any,
 > extends Element<StyleProps, ParsedStyleProps> {
   /**
    * contains style props in constructor's params, eg. fill, stroke...

--- a/packages/g-lite/src/dom/Element.ts
+++ b/packages/g-lite/src/dom/Element.ts
@@ -457,6 +457,9 @@ export class Element<
    */
   destroyed = false;
   destroy() {
+    // fix https://github.com/antvis/G/issues/1813
+    this.destroyChildren();
+
     // destroy itself before remove
     this.dispatchEvent(destroyEvent);
 

--- a/packages/g-lite/src/services/EventService.ts
+++ b/packages/g-lite/src/services/EventService.ts
@@ -1019,7 +1019,6 @@ export class EventService {
 
   private notifyListeners(e: FederatedEvent, type: string) {
     // hack EventEmitter, stops if the `propagationImmediatelyStopped` flag is set
-    // @ts-ignore
     const { emitter } = e.currentTarget;
     // @ts-ignore
     const listeners = (emitter._events as EmitterListeners)[type];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       stats.js:
         specifier: ^0.17.0
         version: 0.17.0
+      tinybench:
+        specifier: ^3.0.3
+        version: 3.0.3
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@16.18.64)(ts-node@10.9.2(@types/node@16.18.64)(typescript@5.6.2)))(typescript@5.6.2)
@@ -6824,6 +6827,10 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tinybench@3.0.3:
+    resolution: {integrity: sha512-uJx7Wn5Dp5qd2TBbbixMaFSxod6HvJxhA7rb55BJD27Gcsz+zoHRA/Gk8pBl91GiWbKtoGqU02XS8GOVJhe1KA==}
+    engines: {node: '>=18.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -14045,6 +14052,8 @@ snapshots:
       readable-stream: 3.6.2
 
   through@2.3.8: {}
+
+  tinybench@3.0.3: {}
 
   tmp@0.0.33:
     dependencies:


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1813 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

The current implementation of `Element.destroy()` only removes the element from the scene graph without destroying its child elements, which results in some cached resources not being released successfully, causing memory leaks.

When an element is destroyed, recursively destroying its child elements is the expected behavior.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: when an element is destroyed, its child elements are not destroyed |
| 🇨🇳 Chinese | fix: 元素销毁时未销毁子元素 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
