### PR TITLE
fix: when image src is an image instance, rendering will not be triggered by default

### DIFF
--- a/.changeset/purple-suns-retire.md
+++ b/.changeset/purple-suns-retire.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-plugin-image-loader': patch
+---
+
+fix: when image src is an image instance, rendering will not be triggered by default

--- a/packages/g-plugin-image-loader/src/LoadImagePlugin.ts
+++ b/packages/g-plugin-image-loader/src/LoadImagePlugin.ts
@@ -36,21 +36,19 @@ export class LoadImagePlugin implements RenderingPlugin {
       if (nodeName === Shape.IMAGE) {
         const { src, keepAspectRatio } = attributes;
 
-        if (isString(src)) {
-          imagePool.getImageSync(
-            src,
-            object as DisplayObject,
-            ({ img: { width, height } }) => {
-              if (keepAspectRatio) {
-                calculateWithAspectRatio(object, width, height);
-              }
+        imagePool.getImageSync(
+          src,
+          object as DisplayObject,
+          ({ img: { width, height } }) => {
+            if (keepAspectRatio) {
+              calculateWithAspectRatio(object, width, height);
+            }
 
-              // set dirty rectangle flag
-              object.renderable.dirty = true;
-              renderingService.dirtify();
-            },
-          );
-        }
+            // set dirty rectangle flag
+            object.renderable.dirty = true;
+            renderingService.dirtify();
+          },
+        );
       }
     };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

When image src is an image instance, rendering will not be triggered by default

```typescript
const img = new Image();
const image = new GImage({
   src: img
});

img.src = 'xxx';
```

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

The reason for this problem is that when passing an image instance, the `complete` property of the image is checked asynchronously to see if it is true, but by default re-rendering is triggered by asynchronous callback only when src is a string.

Therefore, regardless of the type of src, re-rendering should be triggered by asynchronous callback to ensure that the image is correctly rendered after loading successfully.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: when image src is an image instance, rendering will not be triggered by default |
| 🇨🇳 Chinese | fix: 当 image 元素的 src 为图片实例时，默认不会触发渲染 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
