### PR TITLE
fix: fixed the issue where RenderCache could not cache RenderPipeline

### DIFF
--- a/packages/g-plugin-device-renderer/src/render/RenderCache.ts
+++ b/packages/g-plugin-device-renderer/src/render/RenderCache.ts
@@ -187,9 +187,12 @@ export class RenderCache {
     let renderPipeline = this.renderPipelinesCache.get(descriptor);
     if (renderPipeline === null) {
       const descriptorCopy = renderPipelineDescriptorCopy(descriptor);
-      descriptorCopy.colorAttachmentFormats =
-        descriptorCopy.colorAttachmentFormats.filter((f) => f);
-      renderPipeline = this.device.createRenderPipeline(descriptorCopy);
+      renderPipeline = this.device.createRenderPipeline({
+        ...descriptorCopy,
+        colorAttachmentFormats: descriptor.colorAttachmentFormats.filter(
+          (f) => f,
+        ),
+      });
       this.renderPipelinesCache.add(descriptorCopy, renderPipeline);
     }
     return renderPipeline;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
Fix https://github.com/antvis/G/issues/1826
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
修复RenderPipeline无法被缓存的问题

配合上游的[几个PR](https://github.com/antvis/g-device-api/pulls)，现在WebGPU的几个DEMO可以正常跑了
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
