### PR TITLE
refactor: adjust destroy clean-up logic

### DIFF
--- a/.changeset/empty-falcons-occur.md
+++ b/.changeset/empty-falcons-occur.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+refactor: adjust destroy clean-up logic

--- a/__tests__/main.ts
+++ b/__tests__/main.ts
@@ -155,7 +155,7 @@ plot();
 async function plot() {
   if (currentContainer) {
     currentContainer.remove();
-    if (canvas) canvas.destroy();
+    if (canvas) canvas.destroy(false);
     if (prevAfter) prevAfter();
   }
   currentContainer = document.createElement('div');

--- a/packages/g-lite/src/Canvas.ts
+++ b/packages/g-lite/src/Canvas.ts
@@ -394,12 +394,10 @@ export class Canvas extends EventTarget implements ICanvas {
   }
 
   /**
-   * `cleanUp` means clean all the internal services of Canvas which happens when calling `canvas.destroy()`.
+   * @param cleanUp - whether to clean up all the internal services of Canvas
+   * @param skipTriggerEvent - whether to skip trigger destroy event
    */
   destroy(cleanUp = true, skipTriggerEvent?: boolean) {
-    if (skipTriggerEvent === undefined)
-      skipTriggerEvent = this.getConfig().fastCleanExistingCanvas;
-
     if (!skipTriggerEvent) {
       this.dispatchEvent(new CustomEvent(CanvasEvent.BEFORE_DESTROY));
     }
@@ -409,9 +407,9 @@ export class Canvas extends EventTarget implements ICanvas {
 
     // unmount all children
     const root = this.getRoot();
-    this.unmountChildren(root);
 
     if (cleanUp) {
+      this.unmountChildren(root);
       // destroy Document
       this.document.destroy();
       this.getEventService().destroy();
@@ -421,8 +419,8 @@ export class Canvas extends EventTarget implements ICanvas {
     this.getRenderingService().destroy();
     this.getContextService().destroy();
 
-    // clear root after renderservice destroyed
-    if (cleanUp && this.context.rBushRoot) {
+    // clear root after render service destroyed
+    if (this.context.rBushRoot) {
       // clear rbush
       this.context.rBushRoot.clear();
       this.context.rBushRoot = null;


### PR DESCRIPTION
- [x] 调整画布销毁时 cleanUp 逻辑

> cleanUp 为 true 时正常执行 Canvas 及下面各元素的销毁生命周期
> cleanUp 为 false 时，跳过上述逻辑，但不会影响相关内存释放