### PR TITLE
fix: rendering error when line break appears at the beginning of text

### DIFF
--- a/.changeset/two-pumpkins-add.md
+++ b/.changeset/two-pumpkins-add.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: rendering error when line break appears at the beginning of text

--- a/packages/g-lite/src/services/TextService.ts
+++ b/packages/g-lite/src/services/TextService.ts
@@ -380,7 +380,7 @@ export class TextService {
       }
 
       // Backspace from line's end.
-      const currentLineLength = lines[lineIndex].length;
+      const currentLineLength = lines[lineIndex] ? lines[lineIndex].length : 0;
       let lastLineWidth = 0;
       let lastLineIndex = currentLineLength;
       for (let i = 0; i < currentLineLength; i++) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

see https://github.com/antvis/S2/issues/3040

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

If the first character is a line break, the first line of text is null, resulting in an error in getting the character length. We can just check this boundary condition.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: rendering error when line break appears at the beginning of text |
| 🇨🇳 Chinese | fix: 文本首字符为换行符时渲染异常 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
