### PR TITLE
fix: svg path element A command drawing abnormality

### DIFF
--- a/.changeset/long-clouds-yawn.md
+++ b/.changeset/long-clouds-yawn.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: svg path element A command drawing abnormality

--- a/packages/g-lite/src/utils/path.ts
+++ b/packages/g-lite/src/utils/path.ts
@@ -982,7 +982,11 @@ export function translatePathToString(
           return `C ${params[1]} ${params[2]},${params[3]} ${params[4]},${params[5] + endOffsetXTemp} ${params[6] + endOffsetYTemp}`;
 
         case 'A':
-          return `A ${params[1]} ${params[2]} ${params[3]} ${params[4]} ${params[5]} ${params[6] + endOffsetXTemp} ${params[7] + endOffsetYTemp}`;
+          return `A ${params[1]} ${params[2]} ${params[3]} ${params[4]} ${params[5]} ${params[6]} ${params[7]}${
+            useEndOffset
+              ? ` L ${params[6] + endOffsetX},${params[7] + endOffsetY}`
+              : ''
+          }`;
 
         case 'Z':
           return 'Z';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1844

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

When `markerStartOffset`/`markerEndOffset` are set for the path element, the processing of the `A` command differs between canvas and svg. svg directly offsets the last two parameters of the `A` command, while canvas appends an `L` command. 

Considering the complexity of the `A` command, the logic of svg is kept consistent with canvas
to ensure that existing products that rely on this feature work properly.

> https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#elliptical_arc_curve

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: svg path element A command drawing abnormality |
| 🇨🇳 Chinese | fix: svg path 元素的 A 命令绘制异常 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
