### PR TITLE
fix: the text wrapping position is not accurate

### DIFF
--- a/.changeset/silver-tigers-roll.md
+++ b/.changeset/silver-tigers-roll.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: the text wrapping position is not accurate

--- a/__tests__/demos/bugfix/textWordWrap.ts
+++ b/__tests__/demos/bugfix/textWordWrap.ts
@@ -1,5 +1,9 @@
 import { Canvas, Text, Rect } from '@antv/g';
+import * as tinybench from 'tinybench';
 
+/**
+ * @link https://github.com/antvis/G/issues/1833
+ */
 export async function textWordWrap(context: { canvas: Canvas }) {
   const { canvas } = context;
   await canvas.ready;
@@ -105,4 +109,44 @@ export async function textWordWrap(context: { canvas: Canvas }) {
   canvas.appendChild(rect1);
   canvas.appendChild(text2);
   canvas.appendChild(rect2);
+
+  // benchmark
+  // ----------
+  const bench = new tinybench.Bench({
+    name: 'canvas text benchmark',
+    time: 100,
+  });
+
+  const canvasEl = document.createElement('canvas');
+  const testText = 'Hello, World!';
+  bench.add('Measure the entire text at once', async () => {
+    canvasEl.getContext('2d').measureText(testText);
+  });
+  bench.add('Character-by-character measurement', async () => {
+    const ctx = canvasEl.getContext('2d');
+    Array.from(testText).forEach((char) => {
+      ctx.measureText(char);
+    });
+  });
+
+  const testText1 =
+    'In G, text line break detection is currently done by iteratively measuring the width of each character and then adding them up to determine whether a line break is needed. External users may configure wordWrapWidth by directly measuring the width of the entire text. The two different text measurement methods will lead to visual inconsistencies.';
+  bench.add('(long txt) Measure the entire text at once', async () => {
+    canvasEl.getContext('2d').measureText(testText1);
+  });
+  bench.add('(long txt) Character-by-character measurement', async () => {
+    const ctx = canvasEl.getContext('2d');
+    Array.from(testText1).forEach((char) => {
+      ctx.measureText(char);
+    });
+  });
+
+  await bench.run();
+
+  console.log(bench.name);
+  console.table(bench.table());
+  console.log(bench.results);
+  console.log(bench.tasks);
+
+  // ----------
 }

--- a/__tests__/demos/event/hierarchy.ts
+++ b/__tests__/demos/event/hierarchy.ts
@@ -1,6 +1,6 @@
-import { Circle, Path } from '@antv/g';
+import { Canvas, Circle, Path } from '@antv/g';
 
-export async function hierarchy(context) {
+export async function hierarchy(context: { canvas: Canvas }) {
   const { canvas } = context;
   await canvas.ready;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

#1833 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Measuring text is an expensive operation, so G internally calculates the overall text width on a character-by-character basis and caches it when calculating line breaks. Due to the complexity of text rendering, this results in a larger result than measuring the entire text at once, resulting in less precise line break locations.

However, we cannot simply adjust the character-by-character strategy to measure the entire text, which will cause serious performance problems in scenarios with a long text.

> <img width="980" alt="image" src="https://github.com/user-attachments/assets/ee5d1021-1830-4f0e-a27b-ca460e5b3975" />
> In the case of long text, the performance difference between the two different strategies is two orders of magnitude

On the other hand, we can combine the two strategies, use the character-by-character and cache strategies to calculate a rough line break position, and then use the measurement of the entire text near the threshold to get the precise result. Usually, the difference in the position calculated by the two different strategies is within 1-3 characters, so the performance consumption is acceptable, and more importantly, it brings better visual effects.

Before

<img width="207" alt="image" src="https://github.com/user-attachments/assets/503de82b-2ec0-468a-823c-948fc42f4096" />

<img width="208" alt="image" src="https://github.com/user-attachments/assets/286b4b9d-d782-4be3-94c1-595915339cae" />


After

<img width="204" alt="image" src="https://github.com/user-attachments/assets/d794f564-9e2b-4d0d-b3a4-0e1c0d1e833a" />

<img width="208" alt="image" src="https://github.com/user-attachments/assets/0403fbd5-d9ad-49da-bbaa-04be74a24928" />

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: the text wrapping position is not accurate |
| 🇨🇳 Chinese | fix: 文本换行位置不准确 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
