### PR TITLE
fix: line break position does not take into account newline characters

### DIFF
--- a/.changeset/sour-hornets-turn.md
+++ b/.changeset/sour-hornets-turn.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: line break position does not take into account newline characters

--- a/__tests__/demos/bugfix/textWordWrap.ts
+++ b/__tests__/demos/bugfix/textWordWrap.ts
@@ -83,14 +83,14 @@ export async function textWordWrap(context: { canvas: Canvas }) {
       fontSize: 12,
       fontWeight: 'normal',
       linkTextFill: '#326EF4',
-      maxLines: 3,
+      maxLines: 1,
       opacity: 1,
       text: '哈哈哈哈\n哈哈哈哈\n哈哈哈哈\n',
       // textAlign: 'right',
       textBaseline: 'top',
       textOverflow: 'ellipsis',
       wordWrap: true,
-      wordWrapWidth: 84,
+      wordWrapWidth: 30,
     },
   });
   const rect2 = new Rect({

--- a/packages/g-lite/src/services/TextService.ts
+++ b/packages/g-lite/src/services/TextService.ts
@@ -338,6 +338,7 @@ export class TextService {
     parsedStyle: ParsedTextStyleProps,
     offscreenCanvas: CanvasLike,
   ): string {
+    const self = this;
     const {
       wordWrapWidth = 0,
       letterSpacing = 0,
@@ -388,6 +389,9 @@ export class TextService {
         calcWidth(txt) < widthThreshold &&
         textCharIndex < chars.length - 1
       ) {
+        if (self.isNewline(chars[textCharIndex + 1])) {
+          break;
+        }
         textCharIndex += 1;
         txt += chars[textCharIndex];
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

#1833 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

see #1876 

When correcting the calculation of line break positions, line breaks were not taken into account, resulting in abnormal display when line breaks existed in the final rendered text.

Before

<img width="120" alt="image" src="https://github.com/user-attachments/assets/18695651-cd43-46b7-b63a-730b452fac17" />


After

<img width="122" alt="image" src="https://github.com/user-attachments/assets/d3346c10-d608-4804-a62a-294d17050292" />


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: line break position does not take into account newline characters |
| 🇨🇳 Chinese | fix: 换行位置计算未考虑换行符 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
