### PR TITLE
fix: multi-line text wrapping exception

### DIFF
--- a/.changeset/popular-items-wave.md
+++ b/.changeset/popular-items-wave.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: multi-line text wrapping exception

--- a/__tests__/demos/bugfix/textWordWrap.ts
+++ b/__tests__/demos/bugfix/textWordWrap.ts
@@ -90,7 +90,7 @@ export async function textWordWrap(context: { canvas: Canvas }) {
       textBaseline: 'top',
       textOverflow: 'ellipsis',
       wordWrap: true,
-      wordWrapWidth: 30,
+      wordWrapWidth: 84,
     },
   });
   const rect2 = new Rect({
@@ -103,12 +103,43 @@ export async function textWordWrap(context: { canvas: Canvas }) {
     },
   });
 
+  const text3 = new Text({
+    style: {
+      x: 300,
+      y: 300,
+      wordWrap: true,
+      wordWrapWidth: 2,
+      maxLines: 5,
+      textOverflow: 'ellipsis',
+      fontFamily: 'Roboto, PingFangSC, Microsoft YaHei, Arial, sans-serif',
+      fontSize: 12,
+      fontWeight: 700,
+      fill: '#000000',
+      opacity: 1,
+      textAlign: 'center',
+      textBaseline: 'middle',
+      linkTextFill: '#326EF4',
+      text: '千亿数据',
+    },
+  });
+  const rect3 = new Rect({
+    style: {
+      x: text3.style.x,
+      y: text3.style.y,
+      width: text3.style.wordWrapWidth,
+      height: +text3.style.fontSize * text3.style.maxLines,
+      stroke: '#000000',
+    },
+  });
+
   canvas.appendChild(text0);
   canvas.appendChild(rect0);
   canvas.appendChild(text1);
   canvas.appendChild(rect1);
   canvas.appendChild(text2);
   canvas.appendChild(rect2);
+  canvas.appendChild(text3);
+  canvas.appendChild(rect3);
 
   // benchmark
   // ----------


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

#1833 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

see #1876 

When calculating the line break position, a more accurate result is obtained by adopting a strategy of character-by-character measurement cache combined with whole-text measurement. Among them, when the whole-text measurement strategy is used to approximate the optimal value character by character near the threshold, it is not considered that when a single character cannot be displayed, the character-by-character correction will cause the starting character position of each line to return to the beginning of the whole text, resulting in abnormal display after multiple lines of text are wrapped.

In order to deal with this edge case, the index of the last character of each line should be recorded, and when calculating the line break position of the current line, the starting character index of the current line should be used as the boundary condition.

Before

<img width="52" alt="image" src="https://github.com/user-attachments/assets/988a1cd5-10e5-48e4-864b-2719eab7277c" />


After

<img width="49" alt="image" src="https://github.com/user-attachments/assets/327ff70d-59e6-47c1-836b-71264217f619" />


### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: multi-line text wrapping exception |
| 🇨🇳 Chinese | fix: 多行文本换行异常 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
