### PR TITLE
fix: image element rendering triggers an exception

### DIFF
--- a/.changeset/loud-icons-press.md
+++ b/.changeset/loud-icons-press.md
@@ -1,0 +1,6 @@
+---
+'@antv/g-plugin-canvas-renderer': patch
+'@antv/g-plugin-image-loader': patch
+---
+
+fix: image element rendering triggers an exception

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
     'import/no-cycle': 'warn',
     'import/no-duplicates': 'warn',
     'class-methods-use-this': 'warn',
+    'no-console': ['warn', { allow: ['warn', 'error'] }],
     'no-plusplus': [
       'warn',
       {

--- a/__tests__/demos/bugfix/1906.ts
+++ b/__tests__/demos/bugfix/1906.ts
@@ -1,0 +1,33 @@
+import { Canvas, Image as GImage } from '@antv/g';
+
+/**
+ * @see https://github.com/antvis/G/pull/1906
+ */
+export async function issue_1906(context: { canvas: Canvas }) {
+  const { canvas } = context;
+  await canvas.ready;
+  canvas.context.config.enableLargeImageOptimization = true;
+
+  const img = new Image();
+  img.onload = () => {
+    console.log('onload', img.complete);
+
+    // remove && expect no error
+    requestAnimationFrame(() => {
+      image.remove();
+    });
+  };
+
+  let image = new GImage({
+    style: {
+      x: 0,
+      y: 0,
+      src: img,
+    },
+  });
+
+  img.src =
+    'https://mdn.alipayobjects.com/huamei_fr7vu1/afts/img/A*SqloToP7R9QAAAAAAAAAAAAADkn0AQ/original';
+
+  canvas.appendChild(image);
+}

--- a/__tests__/demos/bugfix/index.ts
+++ b/__tests__/demos/bugfix/index.ts
@@ -10,6 +10,7 @@ export { test_pick } from './1747';
 export { issue_1760 } from './1760';
 export { issue_1176 } from './1176';
 export { issue_1882 } from './1882';
+export { issue_1906 } from './1906';
 export { textWordWrap } from './textWordWrap';
 export { group_with_stroke } from './group-with-stroke';
 export { switchRenderer } from './switch-renderer';

--- a/packages/g-plugin-canvas-renderer/src/shapes/styles/Image.ts
+++ b/packages/g-plugin-canvas-renderer/src/shapes/styles/Image.ts
@@ -47,14 +47,19 @@ export class ImageRenderer extends DefaultRenderer {
     if (!imageCache.downSampled) {
       this.imagePool
         .createDownSampledImage(src, object)
-        .then((res) => {
+        .then(() => {
+          // be removed from dom tree
+          if (!object.ownerDocument) {
+            return;
+          }
+
           // rerender
           // object.dirty();
           object.renderable.dirty = true;
           object.ownerDocument.defaultView.context.renderingService.dirtify();
         })
-        .catch(() => {
-          //
+        .catch((reason) => {
+          console.error(reason);
         });
 
       return;
@@ -92,6 +97,11 @@ export class ImageRenderer extends DefaultRenderer {
           src,
           [],
           () => {
+            // be removed from dom tree
+            if (!object.ownerDocument) {
+              return;
+            }
+
             // rerender
             // object.dirty();
             object.renderable.dirty = true;
@@ -99,8 +109,8 @@ export class ImageRenderer extends DefaultRenderer {
           },
           object,
         )
-        .catch(() => {
-          //
+        .catch((reason) => {
+          console.error(reason);
         });
 
       return;
@@ -244,7 +254,9 @@ export class ImageRenderer extends DefaultRenderer {
         imageRect,
         drawRect,
       });
-    } catch {}
+    } catch {
+      // expected error
+    }
   }
 
   // ---

--- a/packages/g-plugin-image-loader/src/ImagePool.ts
+++ b/packages/g-plugin-image-loader/src/ImagePool.ts
@@ -85,8 +85,8 @@ export class ImagePool {
       .then((cache) => {
         callback?.(cache);
       })
-      .catch(() => {
-        //
+      .catch((reason) => {
+        console.error(reason);
       });
 
     return null;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

When the `enableLargeImageOptimization` configuration item is turned on, the rendering of large-size images will no longer be synchronous, and slices and downsampled image data will be generated asynchronously before triggering rendering. During this asynchronous slicing process, if the element object has been removed from the DOM tree, an error will be reported.

```ts
object.ownerDocument.defaultView.context.renderingService.dirtify();
```

At this time, `object.ownerDocument=null`.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

Considering the edge cases, after the image data is asynchronously prepared, it is necessary to determine whether the Image object instance has been removed from the DOM tree before executing the subsequent logic.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: image element rendering triggers an exception |
| 🇨🇳 Chinese | fix: image 元素渲染触发异常 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
