### PR TITLE
fix: element z-index sorting rendering abnormality

### DIFF
--- a/.changeset/sour-dogs-fly.md
+++ b/.changeset/sour-dogs-fly.md
@@ -1,0 +1,7 @@
+---
+'@antv/g-plugin-canvaskit-renderer': patch
+'@antv/g-plugin-canvas-renderer': patch
+'@antv/g-lite': patch
+---
+
+fix: element z-index sorting rendering abnormality

--- a/__tests__/demos/bugfix/1910.ts
+++ b/__tests__/demos/bugfix/1910.ts
@@ -1,0 +1,74 @@
+import { Canvas, Text, CanvasEvent } from '@antv/g';
+import { Renderer } from '@antv/g-canvas';
+
+// const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+// const randomLetter = () => letters.charAt(Math.floor(Math.random() * 26));
+
+/**
+ * @see https://github.com/antvis/G/issues/1910
+ */
+export async function issue_1910(context: { canvas: Canvas }) {
+  const { canvas } = context;
+  console.log(canvas);
+
+  canvas.setRenderer(
+    new Renderer({
+      enableAutoRendering: false,
+    }),
+  );
+
+  const canvasDom = canvas
+    .getContextService()
+    .getDomElement() as unknown as HTMLCanvasElement;
+  const btnDom = document.createElement('button');
+  btnDom.style.cssText =
+    'position: absolute; top: 0px; left: 600px; width: 120px; height: 32px';
+  btnDom.textContent = 'trigger render';
+
+  canvasDom.parentElement.appendChild(btnDom);
+
+  const text1 = new Text({
+    style: {
+      x: 100,
+      y: 200,
+      text: 'A',
+      fontSize: 16,
+      fill: '#f00',
+      zIndex: 1, // zIndex 为 0 或不配置时，一切正常
+    },
+  });
+
+  const text2 = new Text({
+    style: {
+      x: 100,
+      y: 300,
+      text: 'B',
+      fontSize: 16,
+      fill: '#000',
+    },
+  });
+
+  canvas.addEventListener(CanvasEvent.READY, () => {
+    canvas.appendChild(text1);
+    canvas.appendChild(text2);
+    canvas.render();
+
+    btnDom.onclick = () => {
+      canvas.removeChild(text1);
+      canvas.removeChild(text2);
+      console.log('removed');
+
+      canvas.render(); // 添加这行代码后不会出现锯齿，但会有图元丢失问题
+
+      // text1.style.text = randomLetter();
+      text1.style.zIndex = Math.round(Math.random());
+      // text2.style.text = randomLetter();
+
+      canvas.appendChild(text1);
+      canvas.appendChild(text2);
+      console.log('appended');
+
+      canvas.render();
+    };
+  });
+}

--- a/__tests__/demos/bugfix/index.ts
+++ b/__tests__/demos/bugfix/index.ts
@@ -11,6 +11,7 @@ export { issue_1760 } from './1760';
 export { issue_1176 } from './1176';
 export { issue_1882 } from './1882';
 export { issue_1906 } from './1906';
+export { issue_1910 } from './1910';
 export { issue_1911 } from './1911';
 export { textWordWrap } from './textWordWrap';
 export { group_with_stroke } from './group-with-stroke';

--- a/packages/g-lite/src/services/SceneGraphService.ts
+++ b/packages/g-lite/src/services/SceneGraphService.ts
@@ -129,6 +129,7 @@ export class DefaultSceneGraphService implements SceneGraphService {
     const { sortable } = parent as unknown as Element;
     if (
       sortable?.sorted?.length ||
+      sortable.dirty ||
       (child as unknown as Element).parsedStyle.zIndex
     ) {
       if (sortable.dirtyChildren.indexOf(child) === -1) {
@@ -156,42 +157,44 @@ export class DefaultSceneGraphService implements SceneGraphService {
   }
 
   detach<C extends INode>(child: C) {
-    if (child.parentNode) {
-      const transform = (child as unknown as Element).transformable;
-      // if (transform) {
-      //   const worldTransform = this.getWorldTransform(child, transform);
-      //   mat4.getScaling(transform.localScale, worldTransform);
-      //   mat4.getTranslation(transform.localPosition, worldTransform);
-      //   mat4.getRotation(transform.localRotation, worldTransform);
-      //   transform.localDirtyFlag = true;
-      // }
-
-      // parent needs re-sort
-      const { sortable } = child.parentNode as Element;
-      // if (sortable) {
-      if (
-        sortable?.sorted?.length ||
-        (child as unknown as Element).style?.zIndex
-      ) {
-        if (sortable.dirtyChildren.indexOf(child) === -1) {
-          sortable.dirtyChildren.push(child);
-        }
-        sortable.dirty = true;
-        sortable.dirtyReason = SortReason.REMOVED;
-      }
-
-      const index = child.parentNode.childNodes.indexOf(
-        child as unknown as IChildNode & INode,
-      );
-      if (index > -1) {
-        child.parentNode.childNodes.splice(index, 1);
-      }
-
-      if (transform) {
-        this.dirtifyWorld(child, transform);
-      }
-      child.parentNode = null;
+    if (!child.parentNode) {
+      return;
     }
+
+    const transform = (child as unknown as Element).transformable;
+    // if (transform) {
+    //   const worldTransform = this.getWorldTransform(child, transform);
+    //   mat4.getScaling(transform.localScale, worldTransform);
+    //   mat4.getTranslation(transform.localPosition, worldTransform);
+    //   mat4.getRotation(transform.localRotation, worldTransform);
+    //   transform.localDirtyFlag = true;
+    // }
+
+    // parent needs re-sort
+    const { sortable } = child.parentNode as Element;
+    // if (sortable) {
+    if (
+      sortable?.sorted?.length ||
+      (child as unknown as Element).style?.zIndex
+    ) {
+      if (sortable.dirtyChildren.indexOf(child) === -1) {
+        sortable.dirtyChildren.push(child);
+      }
+      sortable.dirty = true;
+      sortable.dirtyReason = SortReason.REMOVED;
+    }
+
+    const index = child.parentNode.childNodes.indexOf(
+      child as unknown as IChildNode & INode,
+    );
+    if (index > -1) {
+      child.parentNode.childNodes.splice(index, 1);
+    }
+
+    if (transform) {
+      this.dirtifyWorld(child, transform);
+    }
+    child.parentNode = null;
   }
 
   getOrigin(element: INode) {

--- a/packages/g-plugin-canvas-renderer/src/CanvasRendererPlugin.ts
+++ b/packages/g-plugin-canvas-renderer/src/CanvasRendererPlugin.ts
@@ -236,7 +236,9 @@ export class CanvasRendererPlugin implements RenderingPlugin {
         }
 
         const objects =
-          currentObject.sortable.sorted || currentObject.childNodes;
+          currentObject.sortable?.sorted?.length > 0
+            ? currentObject.sortable.sorted
+            : currentObject.childNodes;
         // should account for z-index
         for (let i = objects.length - 1; i >= 0; i--) {
           stack.push(objects[i] as unknown as DisplayObject);

--- a/packages/g-plugin-canvaskit-renderer/src/CanvaskitRendererPlugin.ts
+++ b/packages/g-plugin-canvaskit-renderer/src/CanvaskitRendererPlugin.ts
@@ -303,7 +303,10 @@ export class CanvaskitRendererPlugin implements RenderingPlugin {
       this.renderDisplayObject(object, canvas);
     }
 
-    const sorted = object.sortable.sorted || object.childNodes;
+    const sorted =
+      object.sortable?.sorted?.length > 0
+        ? object.sortable.sorted
+        : object.childNodes;
 
     // should account for z-index
     sorted.forEach((child: DisplayObject) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1910 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

In the rendering process, in order to ensure the correct rendering order of child elements, we need to check whether there are child elements with `z-index != 0`. If so, we first sort them and save them to the `sorted` list for rendering. If not, we will directly render them in the `childNodes` list (that is, the order in which the elements are mounted).

There are 3 problems here:

1. In each frame rendering process, by updating the `z-index` of the element, if a parent element no longer has a child element with `z-index != 0`, the rendering list will be abnormal

To solve this problem, it is necessary to determine whether there is a child element with `z-index != 0` after the child elements are sorted. If not, we will clear the `sorted` list to obtain the correct rendering list and order

2. If the parent element has both `z-index == 0` and `z-index != 0` child elements, since the `sorted` list has not been truly refreshed during the element mounting (needs to be triggered by calling `render()`), some elements do not appear in the `sorted` list in the end and cannot be rendered normally

To solve this problem, you only need to determine whether the sorted list is marked as `dirty = true` during the element mounting to ensure that the logic of the data processing process does not depend on the rendering result

3. If the element is unmounted and mounted multiple times before calling `render()`, the final `sorted` There will be multiple references to the same element in the list, which means that the same element will be rendered multiple times (for example, text elements will appear jagged)

When sorting sub-elements in each frame, we need to remove the sub-elements from the `sorted` list first, and then perform subsequent logical processing based on whether the element is mounted or unmounted. If it is a mounted sub-element, we will calculate the element's sorting index and insert it into the appropriate position in the `sorted` list again.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: element z-index sorting rendering abnormality |
| 🇨🇳 Chinese | fix: 元素 z-index 排序渲染异常 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
