### PR TITLE
perf: discard animation when target is destroyed to avoid memory leaks 

### DIFF
--- a/packages/g-web-animations-api/src/dom/Animation.ts
+++ b/packages/g-web-animations-api/src/dom/Animation.ts
@@ -261,6 +261,11 @@ export class Animation implements IAnimation {
    * resolve/reject ready/finished Promise according to current state
    */
   updatePromises() {
+    if (this.effect.target?.destroyed) {
+      this.readyPromise = undefined;
+      this.finishedPromise = undefined;
+      return false;
+    }
     const { oldPlayState } = this;
     const newPlayState = this.pending ? 'pending' : this.playState;
     if (this.readyPromise && newPlayState !== oldPlayState) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/antvis/S2/issues/3092
<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution
在单元格绘制G2 Chart的场景下，横向滚动时会不断地创建新的单元格，销毁旧的单元格。创建单元格后G2的Chart会产生动画，但销毁太快导致动画还没执行单元格Chart已经destroy了。因为@antv/component的Navigator.goto会等待动画finished.then后执行Callback，finished函数会将动画放到G的packages/g-web-animations-api/src/dom/AnimationTimeline.ts的animationsWithPromises数组中等待执行，而动画target已经destroy了，根本得不到执行，导致越攒越多，导致内存泄漏。可以看到下面animationsWithPromises中持有的1597个动画对象，其动画目标元素都已经destroy了，没有必要再持有。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->
![image](https://github.com/user-attachments/assets/0fffac35-d59a-4a47-9075-edda29f2cb74)
![image](https://github.com/user-attachments/assets/5017c509-dc31-4821-909d-44bfc5166fdf)

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Discard animation when target is destroyed      |
| 🇨🇳 Chinese |    在动画目标已经被销毁的情况下，直接丢弃动画，避免内存泄露       |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
