### PR TITLE
fix: prevent rendering of rectangles for elements with 'no-rough' class

### DIFF
--- a/packages/g-plugin-rough-canvas-renderer/src/renderers/Rect.ts
+++ b/packages/g-plugin-rough-canvas-renderer/src/renderers/Rect.ts
@@ -9,14 +9,16 @@ export class RectRenderer implements CanvasRenderer.StyleRenderer {
     object: DisplayObject<any, any>,
   ) {
     const { x = 0, y = 0, width, height } = parsedStyle;
-    // @see https://github.com/rough-stuff/rough/wiki#rectangle-x-y-width-height--options
-    // @ts-ignore
-    context.roughCanvas.rectangle(
-      x,
-      y,
-      width,
-      height,
-      generateRoughOptions(object),
-    );
+    if (!object.attributes.class.includes('no-rough')) {
+      // @see https://github.com/rough-stuff/rough/wiki#rectangle-x-y-width-height--options
+      // @ts-ignore
+      context.roughCanvas.rectangle(
+        x,
+        y,
+        width,
+        height,
+        generateRoughOptions(object),
+      );
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [x] Bug fix


<!--
1. Describe the source of requirement, like related issue link.
-->


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      prevent rendering of rectangles for elements with 'no-rough' class     |
| 🇨🇳 Chinese |     防止渲染具有“no-rough”类的元素的矩形      |

### ☑️ Self Check before Merge

- [x] Changelog is provided or not needed


### 问题描述
- g2 和 g6 中使用 rough 插件并设置 fill 相关 style 时，遇到了多余渲染的问题，效果如下，我想要的效果是纯色背景而不是手绘背景。
![image](https://github.com/user-attachments/assets/b5b0597b-4447-4617-ae8a-d3f2ab908b9f)
特此在 className 添加一个属性，用来判断当前的 rect 是否需要进行 rough，借此来减少多余的 rough 渲染。
- 向后兼容性：原来的对象都没有设置 'no-rough' 类，这个条件判断始终为真，原来的代码会像以前一样执行，不会有任何变化，不会影响现有的功能。
