### PR TITLE
fix: line width is too small to display any characters

### DIFF
--- a/.changeset/green-jobs-bathe.md
+++ b/.changeset/green-jobs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: terminate immediately when the line width is too small to display any characters

--- a/__tests__/unit/display-objects/text.spec.ts
+++ b/__tests__/unit/display-objects/text.spec.ts
@@ -251,4 +251,22 @@ describe('Text', () => {
     text.style.wordWrap = false;
     expect(text.isOverflowing()).toBe(false);
   });
+
+  it('should terminate when line width is too small to display any character', async () => {
+    await canvas.ready;
+
+    const text = new Text({
+      style: {
+        text: '测试文本',
+        fontSize: 16,
+        wordWrap: true,
+        wordWrapWidth: 0,
+        maxLines: 3,
+      },
+    });
+    const lineRects = text.getLineBoundingRects();
+
+    expect(lineRects.length).toBe(1);
+    expect(text.isOverflowing()).toBe(true);
+  });
 });

--- a/packages/g-lite/src/services/TextService.ts
+++ b/packages/g-lite/src/services/TextService.ts
@@ -464,6 +464,17 @@ export class TextService {
         continue;
       }
 
+      // If current line is empty and char width exceeds max width, no need to continue
+      if (currentLineWidth === 0 && charWidth > maxWidth) {
+        // Only add ellipsis if it can fit in the line
+        if (ellipsis && ellipsisWidth <= maxWidth) {
+          lines[currentLineIndex] = ellipsis;
+        } else {
+          lines[currentLineIndex] = '';
+        }
+        parsedStyle.isOverflowing = true;
+        break;
+      }
       if (currentLineWidth > 0 && currentLineWidth + charWidth > maxWidth) {
         const result = findCharIndexClosestWidthThreshold(
           lines[currentLineIndex],


### PR DESCRIPTION
…y any characters

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

In the past, implementations of text line breaks that encountered a situation where the current line could not display any characters would continue to test the next line until the `maxlines` limit was encountered.


If the `wordWrapWidth` was so small that it couldn't even display a single character, it made no sense to continue testing subsequent lines, and created redundant blank lines.


Now, if the current line encounters an arbitrary character that cannot be displayed, it will be terminated immediately.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: terminate immediately when the line width is too small to display any characters          |
| 🇨🇳 Chinese | fix: 当行宽小到无法展示任意字符时立即终止换行测试 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
