### PR TITLE
fix(rendering): fix render hooks execution order and z-index initialization

### DIFF
--- a/.changeset/swift-feet-tell.md
+++ b/.changeset/swift-feet-tell.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix(rendering): fix render hooks execution order and z-index initialization

--- a/__tests__/demos/2d/z-index.ts
+++ b/__tests__/demos/2d/z-index.ts
@@ -10,6 +10,7 @@ export async function zIndex(context) {
       width: 400,
       height: 200,
       fill: 'blue',
+      zIndex: 1,
     },
   });
   const ul1Text = new Text({
@@ -96,10 +97,10 @@ export async function zIndex(context) {
 
   const zIndexFolder = gui.addFolder('z-index');
   const zIndexConfig = {
-    li1ZIndex: 0,
-    li2ZIndex: 0,
-    ul1ZIndex: 0,
-    ul2ZIndex: 0,
+    li1ZIndex: li1.style.zIndex || 0,
+    li2ZIndex: li2.style.zIndex || 0,
+    ul1ZIndex: ul1.style.zIndex || 0,
+    ul2ZIndex: ul2.style.zIndex || 0,
   };
   zIndexFolder.add(zIndexConfig, 'li1ZIndex', 0, 100).onChange((zIndex) => {
     li1.style.zIndex = zIndex;

--- a/packages/g-lite/src/Canvas.ts
+++ b/packages/g-lite/src/Canvas.ts
@@ -233,6 +233,8 @@ export class Canvas extends EventTarget implements ICanvas {
 
       unculledEntities: [],
 
+      renderListCurrentFrame: [],
+
       renderReasons: new Set(),
 
       force: false,

--- a/packages/g-lite/src/services/RenderingContext.ts
+++ b/packages/g-lite/src/services/RenderingContext.ts
@@ -1,4 +1,4 @@
-import type { Group } from '../display-objects';
+import type { DisplayObject, Group } from '../display-objects';
 
 /**
  * why we need re-render
@@ -23,6 +23,8 @@ export interface RenderingContext {
    * reason of re-render, reset after every renderred frame
    */
   renderReasons: Set<RenderReason>;
+
+  renderListCurrentFrame: DisplayObject[];
 
   unculledEntities: number[];
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

In #1944 , we adjusted the execution order of some hooks in the rendering process, hoping to reduce complexity, but due to the implementation differences of different plug-ins, this caused some problems. For example, the Canvas renderer performs rendering in the `endFrame` of each frame, while the SVG renderer executes part of the rendering logic in the `beginFrame` of each frame.

For the time being, for stability reasons, we will prioritize reverting these changes. We will need to refactor the implementation logic of the unified plugin later.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(rendering): fix render hooks execution order and z-index initialization |
| 🇨🇳 Chinese | fix(rendering): 修复渲染钩子执行顺序和 z-index 初始化 |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
