### PR TITLE
perf: Avoid duplicate dirty parent elements to improve performance by 2%

### DIFF
--- a/packages/g-lite/src/services/SceneGraphService.ts
+++ b/packages/g-lite/src/services/SceneGraphService.ts
@@ -938,7 +938,7 @@ export class DefaultSceneGraphService implements SceneGraphService {
       element.ownerDocument?.defaultView?.getConfig()?.future
         ?.experimentalAttributeUpdateOptimization === true;
 
-    while (p && !(p as Element).renderable?.dirty) {
+    while (p && !((p as Element).renderable?.dirty && (p as Element).renderable?.boundsDirty)) {
       (p as Element).dirty?.(true, true);
 
       if (enableAttributeUpdateOptimization) {

--- a/packages/g-lite/src/services/SceneGraphService.ts
+++ b/packages/g-lite/src/services/SceneGraphService.ts
@@ -938,7 +938,7 @@ export class DefaultSceneGraphService implements SceneGraphService {
       element.ownerDocument?.defaultView?.getConfig()?.future
         ?.experimentalAttributeUpdateOptimization === true;
 
-    while (p) {
+    while (p && !(p as Element).renderable?.dirty) {
       (p as Element).dirty?.(true, true);
 
       if (enableAttributeUpdateOptimization) {

--- a/packages/g-lite/src/services/SceneGraphService.ts
+++ b/packages/g-lite/src/services/SceneGraphService.ts
@@ -938,7 +938,13 @@ export class DefaultSceneGraphService implements SceneGraphService {
       element.ownerDocument?.defaultView?.getConfig()?.future
         ?.experimentalAttributeUpdateOptimization === true;
 
-    while (p && !((p as Element).renderable?.dirty && (p as Element).renderable?.boundsDirty)) {
+    while (
+      p &&
+      !(
+        (p as Element).renderable?.dirty &&
+        (p as Element).renderable?.boundsDirty
+      )
+    ) {
       (p as Element).dirty?.(true, true);
 
       if (enableAttributeUpdateOptimization) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

s2滚动场景下，有大量嵌套的节点会走到dirtyToRoot。排在前面的元素自下而上dirty后，排在后面的元素不需要再给父元素dirty了。

| before   | After |
| ---------- | --------- |
|  <img width="1022" height="58" alt="image" src="https://github.com/user-attachments/assets/192c8abd-4dc7-4ce1-8701-025c8a78c056" />  |  <img width="1080" height="66" alt="image" src="https://github.com/user-attachments/assets/dbb61e30-f6bf-41f8-bd60-ebaa0949b0b0" />  |

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Avoid duplicate dirty parent elements to improve performance by 2%       |
| 🇨🇳 Chinese |     避免重复dirty父级元素提升2%性能      |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
