### PR TITLE
fix: prevent NaN in transform calculations when scale is 0

### DIFF
--- a/.changeset/all-dots-check.md
+++ b/.changeset/all-dots-check.md
@@ -1,0 +1,5 @@
+---
+'@antv/g-lite': patch
+---
+
+fix: prevent NaN in transform calculations when scale is 0

--- a/__tests__/demos/2d/transform.ts
+++ b/__tests__/demos/2d/transform.ts
@@ -4,6 +4,17 @@ export async function transform(context) {
   const { canvas } = context;
   await canvas.ready;
 
+  const circle0 = new Circle({
+    style: {
+      cx: 50,
+      cy: 50,
+      r: 20,
+      fill: 'blue',
+      transform: 'scale(0)',
+    },
+  });
+  canvas.appendChild(circle0);
+
   const circle1 = new Circle({
     style: {
       cx: 100,

--- a/__tests__/unit/css/properties/transform.spec.ts
+++ b/__tests__/unit/css/properties/transform.spec.ts
@@ -233,6 +233,31 @@ describe('CSSPropertyTransform', () => {
     expect(circle.getLocalBounds().halfExtents).toStrictEqual([25, 25, 0]);
   });
 
+  it('should handle scale(0) transform correctly without returning NaN in bounds', async () => {
+    const circle = new Circle({
+      style: {
+        cx: 10,
+        cy: 10,
+        r: 50,
+        transform: 'scale(0)',
+      },
+    });
+
+    await canvas.ready;
+    canvas.appendChild(circle);
+
+    const bounds = circle.getBounds();
+    expect(bounds).toBeDefined();
+
+    expect(bounds.center.every(Number.isFinite)).toBeTruthy();
+    expect(bounds.halfExtents.every(Number.isFinite)).toBeTruthy();
+    expect(bounds.min.every(Number.isFinite)).toBeTruthy();
+    expect(bounds.max.every(Number.isFinite)).toBeTruthy();
+
+    expect(bounds.center).toStrictEqual([10, 10, 0]);
+    // expect(bounds.halfExtents).toStrictEqual([0, 0, 0]);
+  });
+
   it("should reset transform with 'none' keyword correctly.", async () => {
     const circle = new Circle({
       style: {

--- a/packages/g-lite/src/utils/transform-mat4.ts
+++ b/packages/g-lite/src/utils/transform-mat4.ts
@@ -14,6 +14,7 @@ import { deg2rad } from './math';
  * causing exceptions
  */
 const MIN_SCALE = 0.000001;
+const clampScale = (item: number) => Math.max(item, MIN_SCALE);
 
 function createSkewMatrix(skewMatrix: mat4, skewX: number, skewY: number) {
   // Create an identity matrix
@@ -32,34 +33,32 @@ const parser: Record<TransformType, (d: CSSUnitValue[]) => void> = {
   scale: (d: CSSUnitValue[]) => {
     mat4.fromScaling(
       $mat4_1,
-      [d[0].value, d[1].value, 1].map((item) =>
-        Math.max(item, MIN_SCALE),
-      ) as vec3,
+      [d[0].value, d[1].value, 1].map((item) => clampScale(item)) as vec3,
     );
   },
   scaleX: (d: CSSUnitValue[]) => {
     mat4.fromScaling(
       $mat4_1,
-      [d[0].value, 1, 1].map((item) => Math.max(item, MIN_SCALE)) as vec3,
+      [d[0].value, 1, 1].map((item) => clampScale(item)) as vec3,
     );
   },
   scaleY: (d: CSSUnitValue[]) => {
     mat4.fromScaling(
       $mat4_1,
-      [1, d[0].value, 1].map((item) => Math.max(item, MIN_SCALE)) as vec3,
+      [1, d[0].value, 1].map((item) => clampScale(item)) as vec3,
     );
   },
   scaleZ: (d: CSSUnitValue[]) => {
     mat4.fromScaling(
       $mat4_1,
-      [1, 1, d[0].value].map((item) => Math.max(item, MIN_SCALE)) as vec3,
+      [1, 1, d[0].value].map((item) => clampScale(item)) as vec3,
     );
   },
   scale3d: (d: CSSUnitValue[]) => {
     mat4.fromScaling(
       $mat4_1,
       [d[0].value, d[1].value, d[2].value].map((item) =>
-        Math.max(item, MIN_SCALE),
+        clampScale(item),
       ) as vec3,
     );
   },

--- a/packages/g-lite/src/utils/transform-mat4.ts
+++ b/packages/g-lite/src/utils/transform-mat4.ts
@@ -6,6 +6,15 @@ import { runtime } from '../global-runtime';
 import type { TransformType } from '../types';
 import { deg2rad } from './math';
 
+/**
+ * Minimum scaling limit
+ *
+ * When `scale` is 0, the matrix will become an irreversible matrix,
+ * and `NaN` will appear during matrix calculation and decomposition,
+ * causing exceptions
+ */
+const MIN_SCALE = 0.000001;
+
 function createSkewMatrix(skewMatrix: mat4, skewX: number, skewY: number) {
   // Create an identity matrix
   mat4.identity(skewMatrix);
@@ -21,19 +30,38 @@ const $mat4_2 = mat4.create();
 
 const parser: Record<TransformType, (d: CSSUnitValue[]) => void> = {
   scale: (d: CSSUnitValue[]) => {
-    mat4.fromScaling($mat4_1, [d[0].value, d[1].value, 1]);
+    mat4.fromScaling(
+      $mat4_1,
+      [d[0].value, d[1].value, 1].map((item) =>
+        Math.max(item, MIN_SCALE),
+      ) as vec3,
+    );
   },
   scaleX: (d: CSSUnitValue[]) => {
-    mat4.fromScaling($mat4_1, [d[0].value, 1, 1]);
+    mat4.fromScaling(
+      $mat4_1,
+      [d[0].value, 1, 1].map((item) => Math.max(item, MIN_SCALE)) as vec3,
+    );
   },
   scaleY: (d: CSSUnitValue[]) => {
-    mat4.fromScaling($mat4_1, [1, d[0].value, 1]);
+    mat4.fromScaling(
+      $mat4_1,
+      [1, d[0].value, 1].map((item) => Math.max(item, MIN_SCALE)) as vec3,
+    );
   },
   scaleZ: (d: CSSUnitValue[]) => {
-    mat4.fromScaling($mat4_1, [1, 1, d[0].value]);
+    mat4.fromScaling(
+      $mat4_1,
+      [1, 1, d[0].value].map((item) => Math.max(item, MIN_SCALE)) as vec3,
+    );
   },
   scale3d: (d: CSSUnitValue[]) => {
-    mat4.fromScaling($mat4_1, [d[0].value, d[1].value, d[2].value]);
+    mat4.fromScaling(
+      $mat4_1,
+      [d[0].value, d[1].value, d[2].value].map((item) =>
+        Math.max(item, MIN_SCALE),
+      ) as vec3,
+    );
   },
   translate: (d: CSSUnitValue[]) => {
     mat4.fromTranslation($mat4_1, [d[0].value, d[1].value, 0]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / Document optimization
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

fixed #1953 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

see https://github.com/antvis/G/issues/1953#issuecomment-3088998453

To ensure that the matrix is always reversible, the determinant must not be `0`, and the diagonal component of the matrix, namely `scale`, must also not be `0`. Therefore, we can set a minimum threshold. When the scale is small enough, the visual element will be invisible and will not affect the existing product visual effects. It may affect the test snapshot, so just update the test benchmark.

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: prevent NaN in transform calculations when scale is 0 |
| 🇨🇳 Chinese | fix: 当 scale 为 0 时，防止在变换计算中出现 NaN |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed